### PR TITLE
feat: CQDG-38 fix user signed in with info in header for orcid users that do not have email

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -123,7 +123,7 @@ const Header = () => {
                     label: (
                       <span className={styles.titleUserDropdown}>
                         {intl.get('layout.user.menu.signedWith') + ' '}
-                        <b>{userInfo?.email}</b>
+                        <b>{tokenParsed.email || tokenParsed.identity_provider_identity}</b>
                       </span>
                     ),
                     key: 'title',


### PR DESCRIPTION
Display email for user logged in with Google
Display orcid ID for user logged in with ORCID

Same behaviour as Include