### PR TITLE
fix: CQDG-76 various fix mondo tree

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -142,8 +142,12 @@ const en = {
         less: 'Less',
         more: 'More',
         apply: 'Apply',
+        cancel: 'Cancel',
       },
       operators: {
+        allOf: 'All of',
+        anyOf: 'Any of',
+        noneOf: 'None of',
         between: 'Between',
         lessthan: 'Less than',
         lessthanorequal: 'Less than or equal',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -144,8 +144,12 @@ const fr = {
         less: 'Moins',
         more: 'Plus',
         apply: 'Appliquer',
+        cancel: 'Annuler',
       },
       operators: {
+        allOf: 'Tout',
+        anyOf: 'N’importe quel',
+        noneOf: 'Aucun',
         between: 'Entre',
         lessthan: 'Moins que',
         lessthanorequal: 'Moins que ou égale',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -38,6 +38,9 @@ export const getFiltersDictionary = (): FiltersDict => ({
     none: intl.get('global.filters.actions.none'),
   },
   operators: {
+    allOf: intl.get('global.filters.operators.allOf'),
+    anyOf: intl.get('global.filters.operators.anyOf'),
+    noneOf: intl.get('global.filters.operators.noneOf'),
     between: intl.get('global.filters.operators.between'),
     lessThan: intl.get('global.filters.operators.lessthan'),
     lessThanOfEqual: intl.get('global.filters.operators.lessthanorequal'),

--- a/src/views/DataExploration/components/TreeFacet/index.tsx
+++ b/src/views/DataExploration/components/TreeFacet/index.tsx
@@ -175,6 +175,7 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
         onClick={() => setVisible(true)}
       />
       <Modal
+        destroyOnClose
         visible={visible}
         wrapClassName={styles.hpoTreeModalWrapper}
         className={styles.hpoTreeModal}
@@ -196,8 +197,8 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
                     label: 'Any of',
                   },
                   {
-                    key: TermOperators.in,
-                    label: 'Any of',
+                    key: TermOperators.all,
+                    label: 'All of',
                   },
                   {
                     key: TermOperators['some-not-in'],
@@ -228,7 +229,7 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
             }
           }}
           onSearch={(_, value) => {
-            if (value && value.length > MIN_SEARCH_TEXT_LENGTH) {
+            if (value && value.length >= MIN_SEARCH_TEXT_LENGTH) {
               const hits: string[] = [];
               const tree = cloneDeep(treeData)!;
               searchInTree(value, tree, hits);

--- a/src/views/DataExploration/components/TreeFacet/index.tsx
+++ b/src/views/DataExploration/components/TreeFacet/index.tsx
@@ -183,7 +183,7 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
         okText={intl.get(`screen.dataExploration.${type}.modal.okText`)}
         footer={[
           <Button key="back" onClick={handleCancel}>
-            Cancel
+            {intl.get('global.filters.actions.cancel')}
           </Button>,
           <Dropdown.Button
             key="treeFacet-footer-dropdown-button"
@@ -194,15 +194,15 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
                 items={[
                   {
                     key: TermOperators.in,
-                    label: 'Any of',
+                    label: intl.get('global.filters.operators.anyOf'),
                   },
                   {
                     key: TermOperators.all,
-                    label: 'All of',
+                    label: intl.get('global.filters.operators.allOf'),
                   },
                   {
                     key: TermOperators['some-not-in'],
-                    label: 'None of',
+                    label: intl.get('global.filters.operators.noneOf'),
                   },
                 ]}
               />
@@ -210,7 +210,7 @@ const TreeFacet = ({ type, field, titleFormatter, queryBuilderId }: ITreeFacetPr
             style={{ marginLeft: '8px' }}
             onClick={() => handleOnApply(TermOperators.in)}
           >
-            Apply
+            {intl.get('global.filters.actions.apply')}
           </Dropdown.Button>,
         ]}
         okButtonProps={{ disabled: isEmpty(targetKeys) && isEmpty(treeData) }}


### PR DESCRIPTION
1. Le sous-menu (Any of, All of, None of) n’est pas correct **FIXED**

2. Depuis la page des Variants, sélectionner des Diagnosis Mondo et faire Apply, ça construit la requête dans la page Data Exploration **CANNOT REPRODUCE**

3. Le Place Holder mentionne que ça prend minimum 3 caractères, mais ça semble plutôt être 4 quand je l’essaie **FIXED**

4. À l’ouverture du modal pour une nouvelle requête, l’ancienne recherche reste affichée **FIXED**

