### PR TITLE
feat: CQDG-351 add overflow to tabs-content

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -21,6 +21,7 @@
 
     :global(.ant-tabs-content) {
         height: 100%;
+        overflow: auto;
     }
 
     :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -19,6 +19,7 @@
 
   :global(.ant-tabs-content) {
     height: 100%;
+    overflow: auto;
   }
 
   :global(.ant-tabs-tab) {


### PR DESCRIPTION
# feat: CQDG-351 add overflow to tabs-content

- closes #TICKET_NUMBER

## Description

https://ferlab-crsj.atlassian.net/browse/CQDG-351

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
<img width="666" alt="image" src="https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/15524246/9b9577ad-ce4d-4313-94c8-706e5ddf08e0">

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

