### PR TITLE
fix: cqdg-387 new string for data release link

### DIFF
--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -618,7 +618,7 @@ const fr = {
     },
     dataRelease: {
       title: 'Données disponibles',
-      dataReleaseLink: 'Publication des données v1.0',
+      dataReleaseLink: 'Version 1.0',
       dataExploration: 'Exploration des données',
     },
   },


### PR DESCRIPTION
# FIX | Data release text

- closes https://ferlab-crsj.atlassian.net/browse/CQDG-387

## Description

Presently the Link reads "Publication de donnés v1.0"

Comportement souhaité

It should be modified to “Version 1.0”

## Validation

- [ ] Code Approved
- [ ] QA Done

## Screenshot
### Before

### After
