### PR TITLE
fix: cqdg-387 new string for data release link EN

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -636,7 +636,7 @@ const en = {
     },
     dataRelease: {
       title: 'Available Data',
-      dataReleaseLink: 'Data release v1.0',
+      dataReleaseLink: 'Version 1.0',
       dataExploration: 'Data Exploration',
     },
   },


### PR DESCRIPTION
# FIX | Data release text

- closes https://ferlab-crsj.atlassian.net/browse/CQDG-387

## Description

Presently the Link reads "Publication de donnés v1.0" 
EN

Comportement souhaité

It should be modified to “Version 1.0”

## Validation

- [ ] Code Approved
- [ ] QA Done

## Screenshot
### Before

### After
