### PR TITLE
fix: CQDG-406 correction double tooltip safari

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.module.scss
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.module.scss
@@ -14,3 +14,9 @@
   overflow-wrap: unset;
   white-space: nowrap;
 }
+
+// prevent safari double tooltip
+.variantTableCellElipsis::after {
+  content: '';
+  display: block;
+}


### PR DESCRIPTION
# FIX | Safari double tooltip

- closes [#TICKET_NUMBER](https://ferlab-crsj.atlassian.net/browse/CQDG-406)

## Description

[JIRA LINK]

only show antd tooltip

## Validation

- [ ] Code Approved
- [ ] QA Done

## Screenshot

### After
![image](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/98903/76ac0169-32c0-470b-ba01-939c4bcdb80a)

