### PR TITLE
Fix/cqdg 448

### DIFF
--- a/src/components/reports/DownloadClinicalDataButton.tsx
+++ b/src/components/reports/DownloadClinicalDataButton.tsx
@@ -1,0 +1,50 @@
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { DownloadOutlined } from '@ant-design/icons';
+import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { Button } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
+
+import { ReportType } from 'services/api/reports/models';
+import { fetchReport } from 'store/report/thunks';
+
+interface IDownloadClinicalDataButtonProps {
+  participantIds?: string[];
+  sqon?: ISqonGroupFilter;
+  type?: 'default' | 'primary';
+}
+
+const DownloadClinicalDataButton = ({
+  participantIds = [],
+  sqon,
+  type = 'default',
+}: IDownloadClinicalDataButtonProps) => {
+  const dispatch = useDispatch();
+
+  const getCurrentSqon = (): any =>
+    sqon || generateSelectionSqon(INDEXES.PARTICIPANT, participantIds);
+
+  return (
+    <Button
+      disabled={!sqon && !participantIds.length}
+      icon={<DownloadOutlined />}
+      onClick={() =>
+        dispatch(
+          fetchReport({
+            data: {
+              sqon: getCurrentSqon(),
+              name: ReportType.CLINICAL_DATA,
+              withFamily: false,
+            },
+          }),
+        )
+      }
+      type={type}
+    >
+      {intl.get('api.report.clinicalData.download')}
+    </Button>
+  );
+};
+
+export default DownloadClinicalDataButton;

--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -18,7 +18,7 @@ import StatsGraph from 'views/StudyEntity/StatsGraph';
 import { pageId, queryId } from 'views/StudyEntity/utils/constant';
 
 import { MAX_ITEMS_QUERY } from 'common/constants';
-import DownloadClinicalDataDropdown from 'components/reports/DownloadClinicalDataDropdown';
+import DownloadClinicalDataButton from 'components/reports/DownloadClinicalDataButton';
 import DownloadFileManifestModal from 'components/reports/DownloadFileManifestModal';
 import DownloadRequestAccessModal from 'components/reports/DownloadRequestAccessModal';
 import { STATIC_ROUTES } from 'utils/routes';
@@ -106,7 +106,7 @@ const StudyEntity = () => {
         loading={loading}
         extra={
           <Space>
-            {!isRestricted && study && <DownloadClinicalDataDropdown sqon={participantSqon} />}
+            {!isRestricted && study && <DownloadClinicalDataButton sqon={participantSqon} />}
             {!isRestricted && study && (
               <DownloadFileManifestModal sqon={fileSqon} hasTooManyFiles={hasTooManyFiles} />
             )}


### PR DESCRIPTION
# FIX : CQDG-448 replace dropdown with single button in StudyEntity
- closeshttps://ferlab-crsj.atlassian.net/browse/CQDG-448

## Description

https://ferlab-crsj.atlassian.net/browse/CQDG-448

Remove dropdown for Download Clinical Data and replace it with a single button to download all data.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### After
![image](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/98903/bc950734-c022-4dd4-bccb-31053a6c4b2e)

## QA

in Study Entity, click on `Download Clinical Data'

## Mention

@kstonge

