### PR TITLE
feat: CQDG-428 fetch study domain on variant entity page

### DIFF
--- a/cypress/e2e/Consultation/PageVariant.cy.ts
+++ b/cypress/e2e/Consultation/PageVariant.cy.ts
@@ -108,7 +108,7 @@ describe('Page d\'un variant - Vérifier les informations affichées', () => {
     cy.get('[id="frequencies"]').find('thead').find('th[class="ant-table-cell"]').eq(4).contains('# ALT Alleles').should('exist');
     cy.get('[id="frequencies"]').find('thead').find('th[class="ant-table-cell"]').eq(5).contains('# Homozygotes').should('exist');
     cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(0).contains('STUDY1').should('exist');
-    cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(1).contains('-').should('exist');
+    cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(1).contains('Rare disease').should('exist');
     cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(2).contains('3 / 3').should('exist');
     cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(3).contains('6.67e-1').should('exist');
     cy.get('[id="frequencies"]').find('tr[class*="ant-table-row"]').eq(0).find('td[class="ant-table-cell"]').eq(4).contains('4').should('exist');

--- a/src/views/VariantEntity/index.tsx
+++ b/src/views/VariantEntity/index.tsx
@@ -9,9 +9,7 @@ import EntityPageWrapper, {
 } from '@ferlab/ui/core/pages/EntityPage';
 import { makeClinvarRows } from '@ferlab/ui/core/pages/EntityPage/utils/pathogenicity';
 import { Space, Tag } from 'antd';
-import { ArrangerEdge } from 'graphql/models';
 import { useVariantEntity } from 'graphql/variants/actions';
-import { IVariantStudyEntity } from 'graphql/variants/models';
 
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
 import { getEntityExpandableTableMultiple } from 'utils/translation';
@@ -62,9 +60,10 @@ const VariantEntity = () => {
     values: [locus],
   });
 
-  const variantStudies = (data?.studies?.hits.edges || []).map(
-    (e: ArrangerEdge<IVariantStudyEntity>) => e.node,
-  );
+  const variantStudies = (data?.studies?.hits.edges || []).map((e) => ({
+    ...e.node,
+    key: e.node.study_code,
+  }));
 
   return (
     <EntityPageWrapper

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ferlab/ui/core/utils/numberUtils';
 import { Space, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
+import { useStudy } from 'graphql/studies/actions';
 import { IVariantEntity, IVariantStudyEntity } from 'graphql/variants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
@@ -18,6 +19,14 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { STATIC_ROUTES } from 'utils/routes';
 
 import styles from '../index.module.scss';
+
+const StudyDomain = ({ study_code }: { study_code: string }) => {
+  const { data: study } = useStudy({
+    field: 'study_code',
+    value: study_code,
+  });
+  return <>{study?.domain || TABLE_EMPTY_PLACE_HOLDER}</>;
+};
 
 export const getFrequenciesItems = (): ProColumnType[] => [
   {
@@ -50,8 +59,8 @@ export const getFrequenciesItems = (): ProColumnType[] => [
   {
     title: intl.get('entities.study.domain'),
     key: 'domain',
-    render: (study: IVariantStudyEntity) => study?.domain || TABLE_EMPTY_PLACE_HOLDER,
     width: '14%',
+    render: (study: IVariantStudyEntity) => study && <StudyDomain study_code={study.study_code} />,
   },
   {
     title: intl.get('entities.variant.frequencies.participants'),
@@ -125,7 +134,7 @@ export const getFrequenciesTableSummaryColumns = (v?: IVariantEntity): TProTable
         : 0,
     },
     {
-      index: 4,
+      index: 5,
       value: v?.internal_frequencies_wgs?.total?.hom
         ? numberFormat(v.internal_frequencies_wgs.total.hom)
         : 0,


### PR DESCRIPTION
# feat: CQDG-428 fetch study domain on variant entity page

- closes #TICKET_NUMBER

## Description

https://ferlab-crsj.atlassian.net/browse/CQDG-428

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
<img width="613" alt="image" src="https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/15524246/9c7f6080-27c0-40bf-9b21-c60465508f91">


## QA

Steps to validate
Url (storybook, ...)
...

## Mention



