### PR TITLE
feat: CQDG-326 add variant sources to tables and facets

### DIFF
--- a/cypress/e2e/Colonnes/TableauVariants.cy.ts
+++ b/cypress/e2e/Colonnes/TableauVariants.cy.ts
@@ -20,6 +20,56 @@ describe('Page des variants - Colonnes du tableau', () => {
       .find('th[class*="ant-table-cell"]').eq(2)
       .should('have.class', 'ant-table-column-has-sorters')
       .contains('Type').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(3)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Sources').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(4)
+      .should('have.class', 'ant-table-column-has-sorters')
+      .contains('dbSNP').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(5)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Most Deleterious Consequence').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(6)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('ClinVar').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(7)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('gnomAD').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(8)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Studies').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(9)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Part.').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(10)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Freq.').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(11)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('ALT').should('exist');
+
+    cy.get('thead[class="ant-table-thead"]')
+      .find('th[class*="ant-table-cell"]').eq(12)
+      .should('not.have.class', 'ant-table-column-has-sorters')
+      .contains('Homo.').should('exist');
   });
 
   it('Masquer/Afficher une colonne affichée', () => {

--- a/cypress/e2e/Consultation/PageVariant.cy.ts
+++ b/cypress/e2e/Consultation/PageVariant.cy.ts
@@ -43,8 +43,9 @@ describe('Page d\'un variant - Vérifier les informations affichées', () => {
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(2).contains('1q23.3').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(3).contains('Reference Genome').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(3).contains('GRCh38').should('exist');
-    cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(4).contains('Source').should('exist');
-    cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(4).contains('-').should('exist');
+    cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(4).contains('Sources').should('exist');
+    cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(4).contains('WGS').should('exist');
+    cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(4).find('[class*="ant-tag-purple"]').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(5).contains('Genes').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(5).contains('FCGR3B').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(6).contains('OMIM').should('exist');

--- a/cypress/e2e/Consultation/TableauVariants.cy.ts
+++ b/cypress/e2e/Consultation/TableauVariants.cy.ts
@@ -13,18 +13,21 @@ describe('Page des variants - Consultation du tableau', () => {
   it('Vérifier les informations affichées', () => {
     cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(1).contains('chr1:g.161629781T>C').should('exist');
     cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(2).contains('SNV').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(3).contains('rs2290834').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(4).find('[class*="moderateImpact"]').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(4).contains('Missense').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(4).contains('FCGR3B').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(4).contains('p.Ile106Val').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(5).contains('Benign').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(6).contains('1.65e-2').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(7).contains(/^1$/).should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(8).contains(/^0$/).should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(9).contains('-').should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(10).contains(/^-$/).should('exist');
-    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(11).contains(/^0$/).should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(3).contains('WGS').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(3).find('[class*="ant-tag-purple"]').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(4).contains('rs2290834').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(5).find('[class*="moderateImpact"]').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(5).contains('Missense').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(5).contains('FCGR3B').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(5).contains('p.Ile106Val').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(6).contains('Benign').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(7).contains('1.65e-2').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(8).contains(/^1$/).should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(9).contains(/^3$/).should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(9).find('[href]').should('not.exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(10).contains('6.67e-1').should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(11).contains(/^4$/).should('exist');
+    cy.get('tr[data-row-key]').eq(0).find('[class*="ant-table-cell"]').eq(12).contains(/^1$/).should('exist');
   });
  
   it('Valider les liens disponibles Lien Variant', () => {
@@ -33,22 +36,22 @@ describe('Page des variants - Consultation du tableau', () => {
   });
  
   it('Valider les liens disponibles Lien dbSNP', () => {
-    cy.get('tr[data-row-key]').eq(0).find('td').eq(3).find('a[href]')
+    cy.get('tr[data-row-key]').eq(0).find('td').eq(4).find('a[href]')
     .should('have.attr', 'href', 'https://www.ncbi.nlm.nih.gov/snp/rs2290834');
   });
  
   it('Valider les liens disponibles Lien Gène', () => {
-    cy.get('tr[data-row-key]').eq(0).find('td').eq(4).find('a[href]')
+    cy.get('tr[data-row-key]').eq(0).find('td').eq(5).find('a[href]')
     .should('have.attr', 'href', 'https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=FCGR3B');
   });
  
   it('Valider les liens disponibles Lien ClinVar', () => {
-    cy.get('tr[data-row-key]').eq(0).find('td').eq(5).find('a[href]')
+    cy.get('tr[data-row-key]').eq(0).find('td').eq(6).find('a[href]')
     .should('have.attr', 'href', 'https://www.ncbi.nlm.nih.gov/clinvar/variation/402858');
   });
  
   it('Valider les liens disponibles Lien Studies', () => {
-    cy.get('tr[data-row-key]').eq(0).find('td').eq(7).find('a[href]').click({force: true});
+    cy.get('tr[data-row-key]').eq(0).find('td').eq(8).find('a[href]').click({force: true});
     cy.get('[data-cy="ProTable_Participants"]').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Study Code').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('STUDY1').should('exist');
@@ -56,7 +59,7 @@ describe('Page des variants - Consultation du tableau', () => {
  
 // Pas de donnée
   it.skip('Valider les liens disponibles Lien Part.', () => {
-    cy.get('tr[data-row-key]').eq(0).find('td').eq(8).find('a[href]').click({force: true});
+    cy.get('tr[data-row-key]').eq(0).find('td').eq(9).find('a[href]').click({force: true});
     cy.get('[data-cy="ProTable_Participants"]').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Participant ID').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('PT').should('exist');
@@ -90,9 +93,9 @@ describe('Page des variants - Consultation du tableau', () => {
     cy.waitWhileSpin(2000);
 
     cy.sortTableAndIntercept('dbSNP', 1);
-    cy.validateTableFirstRow('-', 3);
+    cy.validateTableFirstRow('-', 4);
     cy.sortTableAndIntercept('dbSNP', 1);
-    cy.validateTableFirstRow('rs986294053', 3);
+    cy.validateTableFirstRow('rs986294053', 4);
   });
 
   it('Valider les fonctionnalités du tableau - Tri multiple', () => {

--- a/cypress/e2e/Facettes/PageVariants.cy.ts
+++ b/cypress/e2e/Facettes/PageVariants.cy.ts
@@ -162,6 +162,14 @@ describe('Page des variants (Variant) - Filtrer avec les facettes', () => {
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('Homozygote').should('exist');
     cy.get('div[class*="Header_ProTableHeader"]').contains(/^80$/).should('exist');
   });
+
+  it('Sources - WGS', () => {
+    cy.get('div[class*="Filters_customFilterContainer"]').eq(7).contains('Sources').should('exist');
+    cy.checkValueFacetAndApply(7, 'WGS');
+    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Sources').should('exist');
+    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('WGS').should('exist');
+    cy.get('div[class*="Header_ProTableHeader"]').contains(/^442$/).should('exist');
+  });
 });
 
 describe('Page des variants (Gene) - Filtrer avec les facettes', () => {

--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -216,3 +216,8 @@ export interface IVariantStudyEntity {
 export type ITableVariantEntity = IVariantEntity & {
   key: string;
 };
+
+export enum Sources {
+  WGS = 'WGS',
+  WXS = 'WXS',
+}

--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -181,7 +181,7 @@ export interface IVariantEntity {
   score: number;
   alternate: string;
   assembly_version: string;
-  source: string;
+  sources: string[];
   chromosome: string;
   dna_change: string;
   end: number;

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -12,6 +12,7 @@ export const SEARCH_VARIANT_QUERY = gql`
             assembly_version
             chromosome
             variant_class
+            sources
             clinvar {
               clin_sig
               clinvar_id
@@ -255,6 +256,7 @@ export const GET_VARIANT_ENTITY = gql`
             alternate
             assembly_version
             chromosome
+            sources
             clinvar {
               clin_sig
               clinvar_id

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -170,7 +170,7 @@ const en = {
       alternativeAllele: 'Alternative allele',
       referenceAllele: 'Reference allele',
       referenceGenome: 'Reference Genome',
-      source: 'Source',
+      sources: 'Sources',
       genes: 'Genes',
       gene: 'Gene',
       genePhenotype: 'Gene - Phenotype',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -170,7 +170,7 @@ const fr = {
       alternativeAllele: 'Allèle alternatif',
       referenceAllele: 'Allèle de référence',
       referenceGenome: 'Génome de référence',
-      source: 'Source',
+      sources: 'Sources',
       genes: 'Gènes',
       gene: 'Gène',
       genePhenotype: 'Gène - Phénotype',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -285,6 +285,8 @@ export const getFacetsDictionary = () => ({
   biospecimen_id: intl.get('entities.biospecimen.biospecimen_id'),
   file_id: intl.get('entities.file.file_id'),
   file_2_id: intl.get('entities.file.file_id'),
+  locus: intl.get('entities.variant.variant_id'),
+  sources: intl.get('entities.variant.sources'),
   participant_id: intl.get('entities.participant.participant_id'),
   participant_2_id: intl.get('entities.participant.participant_id'),
   sample_id: intl.get('entities.biospecimen.sample_id'),

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -354,7 +354,6 @@ export const getFacetsDictionary = () => ({
   },
   variant_class: intl.get('entities.variant.variant_class'),
   variant_external_reference: intl.get('entities.variant.variant_external_reference'),
-  locus: intl.get('entities.variant.variant_id'),
   consequences: {
     consequence: intl.get('entities.variant.consequences.consequence'),
     consequences: intl.get('entities.variant.consequences.consequences'),

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -61,7 +61,7 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
           },
           {
             label: intl.get('entities.variant.sources'),
-            value: variant?.sources ? variant.sources.join(', ') : TABLE_EMPTY_PLACE_HOLDER,
+            value: variant?.sources?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
           },
           {
             label: intl.get('entities.variant.genes'),

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -60,8 +60,8 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
             value: variant?.assembly_version || TABLE_EMPTY_PLACE_HOLDER,
           },
           {
-            label: intl.get('entities.variant.source'),
-            value: variant?.source || TABLE_EMPTY_PLACE_HOLDER,
+            label: intl.get('entities.variant.sources'),
+            value: variant?.sources ? variant.sources.join(', ') : TABLE_EMPTY_PLACE_HOLDER,
           },
           {
             label: intl.get('entities.variant.genes'),

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -6,6 +6,7 @@ import { toExponentialNotation } from '@ferlab/ui/core/utils/numberUtils';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import { Tag, Tooltip } from 'antd';
 import { IVariantEntity } from 'graphql/variants/models';
+import { getSourceTagColor } from 'views/Variants/components/PageContent/VariantsTable';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 
@@ -61,7 +62,13 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
           },
           {
             label: intl.get('entities.variant.sources'),
-            value: variant?.sources?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+            value: variant?.sources?.length
+              ? variant?.sources?.map((value) => (
+                  <Tag color={getSourceTagColor(value)} key={value}>
+                    {value || TABLE_EMPTY_PLACE_HOLDER}
+                  </Tag>
+                ))
+              : TABLE_EMPTY_PLACE_HOLDER,
           },
           {
             label: intl.get('entities.variant.genes'),

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -84,26 +84,25 @@ const getDefaultColumns = (): ProColumnType[] => [
     align: 'center',
     render: (sources: string[]) =>
       sources ? (
-        <div>
-          {sources.map((s) => {
-            switch (s) {
-              case Sources.WGS:
-                return (
-                  <Tag key={Sources.WGS} color="purple">
-                    {s}
-                  </Tag>
-                );
-              case Sources.WXS:
-                return (
-                  <Tag key={Sources.WXS} color="orange">
-                    {s}
-                  </Tag>
-                );
-              default:
-                return <Tag key={s}>{TABLE_EMPTY_PLACE_HOLDER}</Tag>;
-            }
+        <>
+          {sources.map((value) => {
+            const getTagColor = (value: string) => {
+              switch (value) {
+                case Sources.WGS:
+                  return 'purple';
+                case Sources.WXS:
+                  return 'orange';
+                default:
+                  return '';
+              }
+            };
+            return (
+              <Tag color={getTagColor(value)} key={value}>
+                {value || TABLE_EMPTY_PLACE_HOLDER}
+              </Tag>
+            );
           })}
-        </div>
+        </>
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -213,6 +213,13 @@ const getDefaultColumns = (): ProColumnType[] => [
     render: (internalFrequencies: IVariantInternalFrequencies) =>
       internalFrequencies?.total?.hom ? numberFormat(internalFrequencies.total.hom) : 0,
   },
+  {
+    key: 'sources',
+    title: intl.get('entities.variant.sources'),
+    dataIndex: 'sources',
+    sorter: { multiple: 1 },
+    render: (sources: string[]) => sources.join(', '),
+  },
 ];
 
 interface IVariantsTableProps {

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -51,6 +51,16 @@ import styles from './index.module.scss';
 
 const isNumber = (n: number) => n && !Number.isNaN(n);
 
+export const getSourceTagColor = (value: string) => {
+  switch (value) {
+    case Sources.WGS:
+      return 'purple';
+    case Sources.WXS:
+      return 'orange';
+    default:
+      return '';
+  }
+};
 const getDefaultColumns = (): ProColumnType[] => [
   {
     key: 'hgvsg',
@@ -85,23 +95,11 @@ const getDefaultColumns = (): ProColumnType[] => [
     render: (sources: string[]) =>
       sources ? (
         <>
-          {sources.map((value) => {
-            const getTagColor = (value: string) => {
-              switch (value) {
-                case Sources.WGS:
-                  return 'purple';
-                case Sources.WXS:
-                  return 'orange';
-                default:
-                  return '';
-              }
-            };
-            return (
-              <Tag color={getTagColor(value)} key={value}>
-                {value || TABLE_EMPTY_PLACE_HOLDER}
-              </Tag>
-            );
-          })}
+          {sources.map((value) => (
+            <Tag color={getSourceTagColor(value)} key={value}>
+              {value || TABLE_EMPTY_PLACE_HOLDER}
+            </Tag>
+          ))}
         </>
       ) : (
         TABLE_EMPTY_PLACE_HOLDER

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -19,7 +19,7 @@ import {
 import { numberFormat, toExponentialNotation } from '@ferlab/ui/core/utils/numberUtils';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import { Tooltip } from 'antd';
+import { Tag, Tooltip } from 'antd';
 import cx from 'classnames';
 import { INDEXES } from 'graphql/constants';
 import { hydrateResults } from 'graphql/models';
@@ -31,6 +31,7 @@ import {
   IVariantEntity,
   IVariantInternalFrequencies,
   IVariantStudyEntity,
+  Sources,
 } from 'graphql/variants/models';
 import { DATA_EXPLORATION_QB_ID, DEFAULT_PAGE_INDEX } from 'views/DataExploration/utils/constant';
 import ConsequencesCell from 'views/Variants/components/ConsequencesCell';
@@ -75,6 +76,37 @@ const getDefaultColumns = (): ProColumnType[] => [
     sorter: { multiple: 1 },
     render: (variant_class: string) =>
       variant_class ? removeUnderscoreAndCapitalize(variant_class) : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'sources',
+    title: intl.get('entities.variant.sources'),
+    dataIndex: 'sources',
+    align: 'center',
+    render: (sources: string[]) =>
+      sources ? (
+        <div>
+          {['WGS'].map((s) => {
+            switch (s) {
+              case Sources.WGS:
+                return (
+                  <Tooltip title={Sources.WGS}>
+                    <Tag color="green">G</Tag>
+                  </Tooltip>
+                );
+              case Sources.WXS:
+                return (
+                  <Tooltip title={Sources.WXS}>
+                    <Tag color="geekblue">E</Tag>
+                  </Tooltip>
+                );
+              default:
+                return <Tag key={s}>{TABLE_EMPTY_PLACE_HOLDER}</Tag>;
+            }
+          })}
+        </div>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'rsnumber',
@@ -212,13 +244,6 @@ const getDefaultColumns = (): ProColumnType[] => [
     key: 'homozygotes',
     render: (internalFrequencies: IVariantInternalFrequencies) =>
       internalFrequencies?.total?.hom ? numberFormat(internalFrequencies.total.hom) : 0,
-  },
-  {
-    key: 'sources',
-    title: intl.get('entities.variant.sources'),
-    dataIndex: 'sources',
-    sorter: { multiple: 1 },
-    render: (sources: string[]) => sources?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -85,19 +85,19 @@ const getDefaultColumns = (): ProColumnType[] => [
     render: (sources: string[]) =>
       sources ? (
         <div>
-          {['WGS'].map((s) => {
+          {sources.map((s) => {
             switch (s) {
               case Sources.WGS:
                 return (
-                  <Tooltip title={Sources.WGS}>
-                    <Tag color="green">G</Tag>
-                  </Tooltip>
+                  <Tag key={Sources.WGS} color="purple">
+                    {s}
+                  </Tag>
                 );
               case Sources.WXS:
                 return (
-                  <Tooltip title={Sources.WXS}>
-                    <Tag color="geekblue">E</Tag>
-                  </Tooltip>
+                  <Tag key={Sources.WXS} color="orange">
+                    {s}
+                  </Tag>
                 );
               default:
                 return <Tag key={s}>{TABLE_EMPTY_PLACE_HOLDER}</Tag>;

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -218,7 +218,7 @@ const getDefaultColumns = (): ProColumnType[] => [
     title: intl.get('entities.variant.sources'),
     dataIndex: 'sources',
     sorter: { multiple: 1 },
-    render: (sources: string[]) => sources.join(', '),
+    render: (sources: string[]) => sources?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -65,6 +65,7 @@ const getFilterGroups = (type: FilterTypes) => {
               'studies__transmission',
               'start',
               'studies__zygosity',
+              'sources',
             ],
             noDataOption: ['start'],
             intervalDecimal: {


### PR DESCRIPTION
# FEAT : [Variant] Séparer fréquences variant pour étude WGS et WXS

- closes #[CQDG-326](https://ferlab-crsj.atlassian.net/browse/CQDG-326)

## Description

- add sources field to variant table
- add sources field into vatiant entity page
- add sources fecette

Please note that the **Fréquences** section of the ticket (see CQDG-326) was done previously with 
https://ferlab-crsj.atlassian.net/browse/CQDG-458

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![Screenshot from 2023-11-01 16-40-05](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/3c2d26fd-8e4b-4fa9-8c6b-82c3bba78b32)

![Screenshot from 2023-11-01 16-41-29](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/e73979b0-bdeb-484c-8853-1d0afb487552)


![Screenshot from 2023-11-01 16-43-17](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/c946b2a6-7a29-4a65-9e55-d520e91716f5)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

