### PR TITLE
fix: CQDG-464 fix email and linkedin edit empty string

### DIFF
--- a/src/services/api/user/models.ts
+++ b/src/services/api/user/models.ts
@@ -10,7 +10,7 @@ export type TUser = {
   era_commons_id?: string;
   nih_ned_id?: string;
   email?: string;
-  public_email?: string;
+  public_email?: string | null;
   external_individual_fullname?: string;
   external_individual_email?: string;
   roles?: string[];
@@ -25,7 +25,7 @@ export type TUser = {
   completed_registration: boolean;
   commercial_use_reason: string;
   config: TUserConfig;
-  linkedin?: string;
+  linkedin?: string | null;
   profile_image_key?: string | null;
 };
 

--- a/src/views/ProfileSettings/cards/Identification/index.tsx
+++ b/src/views/ProfileSettings/cards/Identification/index.tsx
@@ -8,6 +8,7 @@ import { useForm } from 'antd/lib/form/Form';
 import { capitalize } from 'lodash';
 
 import { IncludeKeycloakTokenParsed } from 'common/tokenTypes';
+import { TUser } from 'services/api/user/models';
 import { useUser } from 'store/user';
 import { updateUser } from 'store/user/thunks';
 
@@ -42,6 +43,13 @@ const IdentificationCard = () => {
   const tokenParsed = keycloak.tokenParsed as IncludeKeycloakTokenParsed;
 
   const isValueChanged = () => Object.values(hasChanged).some((val) => val);
+
+  const replaceEmptyEmailAndLinkedin = (user: TUser): TUser => {
+    const userEmailNotEmpty = !user.public_email ? { ...user, public_email: null } : user;
+    return !userEmailNotEmpty.linkedin?.length
+      ? { ...userEmailNotEmpty, linkedin: null }
+      : userEmailNotEmpty;
+  };
 
   const onDiscardChanges = () => {
     setHasChanged(initialChangedValues);
@@ -82,13 +90,14 @@ const IdentificationCard = () => {
               initialValues={initialValues}
               hasChangedInitialValue={hasChanged}
               onHasChanged={setHasChanged}
-              onFinish={(values: any) =>
-                dispatch(
+              onFinish={(values: any) => {
+                const valuesNonEmpty = replaceEmptyEmailAndLinkedin(values);
+                return dispatch(
                   updateUser({
-                    data: values,
+                    data: valuesNonEmpty,
                   }),
-                )
-              }
+                );
+              }}
             >
               <Form.Item
                 name={FORM_FIELDS.FIRST_NAME}


### PR DESCRIPTION
# FIX | Retirer l'email produit une erreur 500

- closes #[CQDG-464](https://ferlab-crsj.atlassian.net/browse/CQDG-464)

## Description
UserApi requires a validated Email or a null value. In case of a empty string it fails.

[JIRA LINK]

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![Screenshot from 2023-11-07 10-49-34](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/1dad6bf2-3181-4749-b64f-68c5253fe439)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

