### PR TITLE
fix: CQDG-474 remove transmission facet

### DIFF
--- a/cypress/e2e/Facettes/PageVariants.cy.ts
+++ b/cypress/e2e/Facettes/PageVariants.cy.ts
@@ -128,44 +128,29 @@ describe('Page des variants (Variant) - Filtrer avec les facettes', () => {
     cy.get('div[class*="Header_ProTableHeader"]').contains(/^500$/).should('exist');
   });
 
-  it('Transmission - Unknown Parents Genotype', () => {
-    cy.get('div[class*="Filters_customFilterContainer"]').eq(4).contains('Transmission').should('exist');
-    cy.checkValueFacetAndApply(4, 'Unknown Parents Genotype');
-    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Transmission').should('exist');
-    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('Unknown Parents Genotype').should('exist');
-    cy.get('div[class*="Header_ProTableHeader"]').contains(/^442$/).should('exist');
-  });
-
-  it.skip('Transmission - Autosomal Dominant De Novo', () => {
-    cy.checkValueFacetAndApply(4, 'Autosomal Dominant De Novo');
-    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Transmission').should('exist');
-    cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('Autosomal Dominant De Novo').should('exist');
-    cy.get('div[class*="Header_ProTableHeader"]').contains(/^7,632$/).should('exist');
-  });
-
   it('Position', () => {
-    cy.get('div[class*="Filters_customFilterContainer"]').eq(5).contains('Position').should('exist');
+    cy.get('div[class*="Filters_customFilterContainer"]').eq(4).contains('Position').should('exist');
     // TODO Filtrer
   });
 
   it('Zygosity - Heterozygote', () => {
-    cy.get('div[class*="Filters_customFilterContainer"]').eq(6).contains('Zygosity').should('exist');
-    cy.checkValueFacetAndApply(6, 'Heterozygote');
+    cy.get('div[class*="Filters_customFilterContainer"]').eq(5).contains('Zygosity').should('exist');
+    cy.checkValueFacetAndApply(5, 'Heterozygote');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Zygosity').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('Heterozygote').should('exist');
     cy.get('div[class*="Header_ProTableHeader"]').contains(/^387$/).should('exist');
   });
 
   it('Zygosity - Homozygote', () => {
-    cy.checkValueFacetAndApply(6, 'Homozygote');
+    cy.checkValueFacetAndApply(5, 'Homozygote');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Zygosity').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('Homozygote').should('exist');
     cy.get('div[class*="Header_ProTableHeader"]').contains(/^80$/).should('exist');
   });
 
   it('Sources - WGS', () => {
-    cy.get('div[class*="Filters_customFilterContainer"]').eq(7).contains('Sources').should('exist');
-    cy.checkValueFacetAndApply(7, 'WGS');
+    cy.get('div[class*="Filters_customFilterContainer"]').eq(6).contains('Sources').should('exist');
+    cy.checkValueFacetAndApply(6, 'WGS');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryPill_field"]').contains('Sources').should('exist');
     cy.get('[class*="QueryBar_selected"]').find('[class*="QueryValues_value"]').contains('WGS').should('exist');
     cy.get('div[class*="Header_ProTableHeader"]').contains(/^442$/).should('exist');

--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -207,7 +207,6 @@ export interface IVariantStudyEntity {
   score: number | null;
   study_code: string;
   study_id: string;
-  transmissions: string[];
   zygosity: string[];
   total: IBoundType;
   domain: string;

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -234,7 +234,6 @@ export const SEARCH_VARIANT_QUERY = gql`
                       af
                       pf
                     }
-                    transmission
                     zygosity
                   }
                 }
@@ -483,7 +482,6 @@ export const GET_VARIANT_ENTITY = gql`
                       af
                       pf
                     }
-                    transmission
                     zygosity
                   }
                 }

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -62,7 +62,6 @@ const getFilterGroups = (type: FilterTypes) => {
               'genes__consequences__consequence',
               'variant_external_reference',
               'chromosome',
-              'studies__transmission',
               'start',
               'studies__zygosity',
               'sources',


### PR DESCRIPTION
# FIX: Retirer le mode de transmission dans les facettes

- closes #[CQDG-474](https://ferlab-crsj.atlassian.net/browse/CQDG-474)

## Description

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
(Transmission facet removed)
![Screenshot from 2023-11-07 15-35-17](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/80ec6bfd-2a8c-4ad9-9401-08d1b966ab72)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

