### PR TITLE
feat: CQDG-459 434 remove fake CAG count

### DIFF
--- a/src/components/uiKit/DataRelease/index.tsx
+++ b/src/components/uiKit/DataRelease/index.tsx
@@ -30,16 +30,7 @@ const DataRelease = ({ className = '' }: IDataReleaseProps) => {
     dispatch(fetchStats());
   }, [dispatch]);
 
-  const {
-    studies = 0,
-    participants = 0,
-    samples = 0,
-    // fileSize = '',
-  } = stats || {};
-
-  //todo: Change after CAG implementation, temporarily added for CQDG-434
-  const cagFilesCount = 2183;
-  const totalFileSize = '11.3TB';
+  const { studies = 0, participants = 0, samples = 0, fileSize = '' } = stats || {};
 
   return (
     <Spin spinning={false}>
@@ -56,7 +47,7 @@ const DataRelease = ({ className = '' }: IDataReleaseProps) => {
         <Col xs={12} md={6} data-cy="DataRelease_Participant">
           <MultiLabel
             iconPosition={MultiLabelIconPositionEnum.Top}
-            label={numberFormat(participants + cagFilesCount)}
+            label={numberFormat(participants)}
             Icon={<UserOutlined className={styles.dataReleaseIcon} />}
             className={styles.dataReleaseStatsLabel}
             subLabel={intl.get('entities.participant.participants')}
@@ -65,7 +56,7 @@ const DataRelease = ({ className = '' }: IDataReleaseProps) => {
         <Col xs={12} md={6} data-cy="DataRelease_Biospecimen">
           <MultiLabel
             iconPosition={MultiLabelIconPositionEnum.Top}
-            label={numberFormat(samples + cagFilesCount)}
+            label={numberFormat(samples)}
             Icon={<ExperimentOutlined className={styles.dataReleaseIcon} />}
             className={styles.dataReleaseStatsLabel}
             subLabel={intl.get('entities.biospecimen.biospecimens')}
@@ -74,7 +65,7 @@ const DataRelease = ({ className = '' }: IDataReleaseProps) => {
         <Col xs={12} md={6} data-cy="DataRelease_File">
           <MultiLabel
             iconPosition={MultiLabelIconPositionEnum.Top}
-            label={totalFileSize}
+            label={fileSize}
             Icon={<FileTextOutlined className={styles.dataReleaseIcon} />}
             className={styles.dataReleaseStatsLabel}
             subLabel={intl.get('entities.file.datafiles')}

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
@@ -31,16 +31,7 @@ const DataExplorationLinks = () => {
     dispatch(fetchStats());
   }, [dispatch]);
 
-  const {
-    studies = 0,
-    participants = 0,
-    samples = 0,
-    // fileSize = '',
-  } = stats || {};
-
-  //todo: Change after CAG implementation, temporarily added for CQDG-434
-  const cagFilesCount = 2183;
-  const totalFileSize = '11.3TB';
+  const { studies = 0, participants = 0, samples = 0, fileSize = '' } = stats || {};
 
   return (
     <GridCard
@@ -79,7 +70,7 @@ const DataExplorationLinks = () => {
             <LinkBox
               href={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
               multiLabelClassName={styles.dataReleaseStatsLabel}
-              label={numberFormat(participants + cagFilesCount)}
+              label={numberFormat(participants)}
               subLabel={intl.get('entities.participant.participants')}
               icon={<UserOutlined className={styles.dataReleaseIcon} />}
             />
@@ -88,7 +79,7 @@ const DataExplorationLinks = () => {
             <LinkBox
               href={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
               multiLabelClassName={styles.dataReleaseStatsLabel}
-              label={numberFormat(samples + cagFilesCount)}
+              label={numberFormat(samples)}
               subLabel={intl.get('entities.biospecimen.biospecimens')}
               icon={<ExperimentOutlined className={styles.dataReleaseIcon} />}
             />
@@ -97,7 +88,7 @@ const DataExplorationLinks = () => {
             <LinkBox
               href={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
               multiLabelClassName={styles.dataReleaseStatsLabel}
-              label={totalFileSize}
+              label={fileSize}
               subLabel={intl.get('entities.file.datafiles')}
               icon={<FileTextOutlined className={styles.dataReleaseIcon} />}
             />


### PR DESCRIPTION
# feat: CQDG-459 434 remove fake CAG count

- closes #TICKET_NUMBER

## Description

Refonte, les chiffres seront trafiqués sur l’api-arranger, en prod seulement:
- cqdg-api-arranger: https://github.com/Ferlab-Ste-Justine/cqdg-api-arranger/pull/24


https://ferlab-crsj.atlassian.net/browse/CQDG-459
https://ferlab-crsj.atlassian.net/browse/CQDG-434

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

