### PR TITLE
fix: CQDG-268 remove non_observed_phenotype_tagged field

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -125,7 +125,6 @@ export interface IParticipantEntity {
   mondo_tagged: ArrangerResultsTree<IMondoTagged>;
   observed_phenotypes: ArrangerResultsTree<IPhenotype>;
   observed_phenotype_tagged: ArrangerResultsTree<IPhenotype>;
-  non_observed_phenotype_tagged: ArrangerResultsTree<IPhenotype>;
   phenotypes_tagged: ArrangerResultsTree<IPhenotype>;
   icd_tagged: ArrangerResultsTree<IIcd>;
   biospecimens: ArrangerResultsTree<IBiospecimenEntity>;

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -173,22 +173,6 @@ export const GET_PARTICIPANTS = gql`
                 }
               }
             }
-            non_observed_phenotype_tagged {
-              hits {
-                total
-                edges {
-                  node {
-                    age_at_event
-                    internal_phenotype_id
-                    is_leaf
-                    is_tagged
-                    name
-                    parents
-                    source_text
-                  }
-                }
-              }
-            }
             diagnoses {
               hits {
                 total


### PR DESCRIPTION
# REFACTOR : Remove non_observed_phenotype_tagged field

- closes #[CQDG-268](https://ferlab-crsj.atlassian.net/browse/CQDG-268)

## Description
Field is in the query, but it is not used. It was removed. No visual impact in the portal.

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
N/A

### After
N/A

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo



[CQDG-268]: https://ferlab-crsj.atlassian.net/browse/CQDG-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ