### PR TITLE
fix: CQDG-477 fix empty filter and sets dashboard cards

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -792,9 +792,10 @@ const en = {
           title: 'Saved Filters',
           popoverTitle: 'Managing Saved Filters',
           popoverContent:
-            'A saved filter is a virtual query created by applying one or more filters to a search query. They can be saved and revisited for later use without having to manually reselect filters in the sidebar. You can create saved filters using the Query Management tool above the table of results in the ',
+            'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           popoverContentLink: 'Data Exploration page',
-          noSaved: 'You have no saved filters',
+          noSaved:
+            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           lastSaved: 'Last saved: {date} ago',
           dataExploration: 'Data Exploration',
           variants: 'Variants',
@@ -804,9 +805,10 @@ const en = {
           title: 'Saved Sets',
           popoverTitle: 'Managing Saved Sets',
           popoverContent:
-            'A saved set is a set of one or more entity IDs that can be saved and revisited for later use without having to manually reselect entity IDs. You can create Participant, Biospecimen, and File saved sets at the top of the table of results in the ',
+            'A saved set is a set of one or more entity IDs that can be saved and revisited for later use without having to manually reselect entity IDs. You can create Participant, Biospecimen, and File saved sets at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           popoverContentLink: 'Data Exploration page',
-          noSaved: 'You have no saved sets',
+          noSaved:
+            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           lastSaved: 'Last saved: {date} ago',
           failedFetch: 'Failed to fetch sets saved',
         },

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -796,9 +796,10 @@ const fr = {
           title: 'Filtres enregistrés',
           popoverTitle: 'Gestion des filtres enregistrés',
           popoverContent:
-            "Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à une requête de recherche. Ils peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les filtres dans la barre latérale. Vous pouvez créer des filtres enregistrés à l'aide de l'outil de gestion des requêtes au-dessus du tableau des résultats dans la ",
+            'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à une requête de recherche. Ils peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les filtres dans la barre latérale. Vous pouvez créer des filtres enregistrés à l\'aide de l\'outil de gestion des requêtes au-dessus du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
           popoverContentLink: 'page Exploration des données',
-          noSaved: "Vous n'avez aucun filtre enregistré",
+          noSaved:
+            'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à un ensemble de données. Enregistrez votre premier filtre depuis la barre de requêtes en haut des pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
           lastSaved: 'Dernier enregistrement : il y a {date}',
           dataExploration: 'Exploration des données',
           variants: 'Variants',
@@ -808,9 +809,10 @@ const fr = {
           title: 'Ensembles enregistrés',
           popoverTitle: 'Gestion des ensembles enregistrés',
           popoverContent:
-            "Un ensemble enregistré est un ensemble d'un ou plusieurs ID d'entité qui peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les ID d'entité. Vous pouvez créer des ensembles enregistrés de participants, d'échantillons biologiques et de fichiers en haut du tableau des résultats dans la ",
+            'Un ensemble enregistré est un ensemble d\'un ou plusieurs ID d\'entité qui peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les ID d\'entité. Vous pouvez créer des ensembles enregistrés de participants, d\'échantillons biologiques et de fichiers en haut du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
           popoverContentLink: 'page Exploration des données',
-          noSaved: 'Vous n’avez aucun ensemble enregistré',
+          noSaved:
+            'Un ensemble enregistré est un ensemble d\'entités qui peuvent être enregistrées et utilisées ultérieurement. Enregistrez votre premier ensemble en haut du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
           lastSaved: 'Dernier enregistrement : il y a {date}',
           failedFetch: 'Échec de la récupération des ensembles enregistrés',
         },

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -22,6 +22,10 @@
     :global(.ant-tabs-content) {
         height: 100%;
         overflow: auto;
+
+        :global(.ant-tabs-tabpane) {
+            height: 100%;
+        }
     }
 
     :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -10,7 +10,6 @@ import CardHeader from 'views/Dashboard/components/CardHeader';
 import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
 
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
-import PopoverContentLink from 'components/uiKit/PopoverContentLink';
 import { SavedFilterTag, TUserSavedFilter } from 'services/api/savedFilter/models';
 import { SUPPORT_EMAIL } from 'store/report/thunks';
 import { useSavedFilter } from 'store/savedFilter';
@@ -47,7 +46,10 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.get('screen.dashboard.cards.savedFilters.noSaved')}
+          description={intl.getHTML('screen.dashboard.cards.savedFilters.noSaved', {
+            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+            variantsHref: STATIC_ROUTES.VARIANTS,
+          })}
         />
       ),
     }}
@@ -105,12 +107,10 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedFilters.popoverTitle'),
             content: (
               <Text>
-                {intl.get('screen.dashboard.cards.savedFilters.popoverContent')}
-                <PopoverContentLink
-                  to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
-                  title={intl.get('screen.dashboard.cards.savedFilters.popoverContentLink')}
-                />
-                .
+                {intl.getHTML('screen.dashboard.cards.savedFilters.popoverContent', {
+                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+                  variantsHref: STATIC_ROUTES.VARIANTS,
+                })}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -20,6 +20,10 @@
   :global(.ant-tabs-content) {
     height: 100%;
     overflow: auto;
+
+    :global(.ant-tabs-tabpane) {
+      height: 100%;
+    }
   }
 
   :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -11,7 +11,6 @@ import CardHeader from 'views/Dashboard/components/CardHeader';
 import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
 
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
-import PopoverContentLink from 'components/uiKit/PopoverContentLink';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
 import { SUPPORT_EMAIL } from 'store/report/thunks';
 import { useSavedSet } from 'store/savedSet';
@@ -20,6 +19,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import ListItem from './ListItem';
 
 import styles from './index.module.scss';
+
 const { Text } = Typography;
 
 const getItemList = (
@@ -49,7 +49,10 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.get('screen.dashboard.cards.savedSets.noSaved')}
+          description={intl.getHTML('screen.dashboard.cards.savedSets.noSaved', {
+            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+            variantsHref: STATIC_ROUTES.VARIANTS,
+          })}
         />
       ),
     }}
@@ -147,12 +150,10 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedSets.popoverTitle'),
             content: (
               <Text>
-                {intl.get('screen.dashboard.cards.savedSets.popoverContent')}
-                <PopoverContentLink
-                  to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
-                  title={intl.get('screen.dashboard.cards.savedSets.popoverContentLink')}
-                />
-                .
+                {intl.getHTML('screen.dashboard.cards.savedSets.popoverContent', {
+                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+                  variantsHref: STATIC_ROUTES.VARIANTS,
+                })}
               </Text>
             ),
           }}


### PR DESCRIPTION
# FIX : Modify Saved Filter and Saved Set Widget text in the Dashboard

- closes #[CQDG-477](https://ferlab-crsj.atlassian.net/browse/CQDG-477)

## Description
Modify the text of the empty card according to the maquete in Figma
https://www.figma.com/file/BxMxKt4h6wF4iMWIeC84mg/include-dashboard-v.1.0?type=design&node-id=638-16093&mode=design&t=uAc7dp9IWAOYIHH8-0 

https://www.figma.com/file/BxMxKt4h6wF4iMWIeC84mg/include-dashboard-v.1.0?type=design&node-id=284-16094&mode=design&t=5HlKPzCgQhuf6Nsa-0 

https://www.figma.com/file/BxMxKt4h6wF4iMWIeC84mg/include-dashboard-v.1.0?type=design&node-id=284-16094&mode=design&t=4aqYkAWVS28Zgp5g-0


Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
(similar for french versions)

### Before

Filters:
![image](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/988be3d2-3a37-49ed-9f6e-970cdcc47b95)

Sets:
![Screenshot from 2024-01-05 14-14-10](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/9e6e4766-6368-49d6-8012-9b606b5dbf05)


### After

Filters:
![Screenshot from 2024-01-05 14-14-52](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/97817483-cb8a-4046-a41d-09043220c09d)

Sets:
![Screenshot from 2024-01-05 14-15-47](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/a392d8e4-d4f3-486c-bca7-ba8b9ea9f0a9)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo



[CQDG-477]: https://ferlab-crsj.atlassian.net/browse/CQDG-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ