### PR TITLE
fix: CQDG-510 space between english and french description

### DIFF
--- a/cypress/e2e/Consultation/PageStudy.cy.ts
+++ b/cypress/e2e/Consultation/PageStudy.cy.ts
@@ -65,6 +65,7 @@ describe('Page d\'une étude - Vérifier les informations affichées', () => {
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(4).find('[class*="StudyEntity_tag_"]').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-label"]').eq(5).contains('Description').should('exist');
     cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(5).contains('Case-parent trio study on developmental and epileptic encephalopaties (DEE)').should('exist');
+    cy.get('[id="summary"]').find('[class="ant-descriptions-item-content"]').eq(5).contains('Description en francais, Case-parent trio study on developmental and epileptic encephalopaties (DEE)').should('exist');
   });
 
   it('Panneau Data Access', () => {

--- a/src/views/StudyEntity/index.module.scss
+++ b/src/views/StudyEntity/index.module.scss
@@ -34,7 +34,6 @@
   text-decoration: none !important;
 }
 
-.whiteSpace {
-  white-space: pre;
-  text-wrap: inherit !important;
+.whiteSpace:not(:last-child) {
+   padding-bottom: 10px;
 }

--- a/src/views/StudyEntity/index.module.scss
+++ b/src/views/StudyEntity/index.module.scss
@@ -36,5 +36,5 @@
 
 .whiteSpace {
   white-space: pre;
-  text-wrap: inherit;
+  text-wrap: inherit !important;
 }

--- a/src/views/StudyEntity/index.module.scss
+++ b/src/views/StudyEntity/index.module.scss
@@ -33,3 +33,7 @@
 .forceLinkUnderline:hover {
   text-decoration: none !important;
 }
+
+.whiteSpace {
+  white-space: pre;
+}

--- a/src/views/StudyEntity/index.module.scss
+++ b/src/views/StudyEntity/index.module.scss
@@ -36,4 +36,5 @@
 
 .whiteSpace {
   white-space: pre;
+  text-wrap: inherit;
 }

--- a/src/views/StudyEntity/index.module.scss
+++ b/src/views/StudyEntity/index.module.scss
@@ -35,5 +35,5 @@
 }
 
 .whiteSpace:not(:last-child) {
-   padding-bottom: 10px;
+   padding-bottom: 22px;
 }

--- a/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
+++ b/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
@@ -49,8 +49,8 @@ const getSummaryDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[]
   {
     label: intl.get('entities.study.description'),
     value:
-      // <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
-      <div className={styles.whiteSpace}>{'TOTO'}</div> || TABLE_EMPTY_PLACE_HOLDER,
+      <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
+      TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
+++ b/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
@@ -48,7 +48,9 @@ const getSummaryDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[]
   },
   {
     label: intl.get('entities.study.description'),
-    value: study?.description || TABLE_EMPTY_PLACE_HOLDER,
+    value:
+      <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
+      TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
+++ b/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
@@ -49,8 +49,8 @@ const getSummaryDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[]
   {
     label: intl.get('entities.study.description'),
     value:
-      <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
-      TABLE_EMPTY_PLACE_HOLDER,
+      // <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
+      <div className={styles.whiteSpace}>{'TOTO'}</div> || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
+++ b/src/views/StudyEntity/utils/getSummaryDescriptions.tsx
@@ -49,8 +49,11 @@ const getSummaryDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[]
   {
     label: intl.get('entities.study.description'),
     value:
-      <div className={styles.whiteSpace}>{study?.description?.replaceAll('|', '\n\n')}</div> ||
-      TABLE_EMPTY_PLACE_HOLDER,
+      study?.description.split('|').map((desc, index) => (
+        <div key={index} className={styles.whiteSpace}>
+          {desc}
+        </div>
+      )) || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 


### PR DESCRIPTION
# FIX : Add space between English and French text in the Description Study Entity page

- closes #[CQDG-510](https://ferlab-crsj.atlassian.net/browse/CQDG-510)

## Description
see ticket

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![Screenshot from 2024-01-09 11-45-09](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/47f2f39b-cebb-41a8-92a3-af3faa7cb502)

### After
![Screenshot from 2024-01-09 11-45-31](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/39bbc5de-f0d9-497e-a782-9eb3ce640352)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo



[CQDG-510]: https://ferlab-crsj.atlassian.net/browse/CQDG-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ