### PR TITLE
fix: CQGD-533 fix variant study frequency mappings

### DIFF
--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -200,6 +200,7 @@ export interface IVariantEntity {
   genes: IArrangerResultsTree<IGeneEntity>;
   internal_frequencies_wgs: IVariantInternalFrequencies;
   studies: IArrangerResultsTree<IVariantStudyEntity>;
+  study_frequencies_wgs: IArrangerResultsTree<IVariantStudyFrequencies>;
 }
 
 export interface IVariantStudyEntity {
@@ -208,12 +209,23 @@ export interface IVariantStudyEntity {
   study_code: string;
   study_id: string;
   zygosity: string[];
-  total: IBoundType;
   domain: string;
+}
+
+export interface IVariantStudyFrequencies {
+  id: string;
+  score: number | null;
+  study_code: string;
+  study_id: string;
+  total: IBoundType;
 }
 
 export type ITableVariantEntity = IVariantEntity & {
   key: string;
+};
+
+export type IVariantStudyEntityWithFrequencies = IVariantStudyEntity & {
+  total: IBoundType;
 };
 
 export enum Sources {

--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -212,20 +212,12 @@ export interface IVariantStudyEntity {
   domain: string;
 }
 
-export interface IVariantStudyFrequencies {
-  id: string;
-  score: number | null;
-  study_code: string;
-  study_id: string;
+export interface IVariantStudyFrequencies extends IVariantStudyEntity {
   total: IBoundType;
 }
 
 export type ITableVariantEntity = IVariantEntity & {
   key: string;
-};
-
-export type IVariantStudyEntityWithFrequencies = IVariantStudyEntity & {
-  total: IBoundType;
 };
 
 export enum Sources {

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -225,15 +225,6 @@ export const SEARCH_VARIANT_QUERY = gql`
                   node {
                     study_code
                     study_id
-                    total {
-                      ac
-                      pc
-                      hom
-                      pn
-                      an
-                      af
-                      pf
-                    }
                     zygosity
                   }
                 }
@@ -473,6 +464,18 @@ export const GET_VARIANT_ENTITY = gql`
                   node {
                     study_code
                     study_id
+                    zygosity
+                  }
+                }
+              }
+            }
+            study_frequencies_wgs {
+              hits {
+                total
+                edges {
+                  node {
+                    study_code
+                    study_id
                     total {
                       ac
                       pc
@@ -482,7 +485,6 @@ export const GET_VARIANT_ENTITY = gql`
                       af
                       pf
                     }
-                    zygosity
                   }
                 }
               }

--- a/src/views/VariantEntity/index.tsx
+++ b/src/views/VariantEntity/index.tsx
@@ -65,6 +65,15 @@ const VariantEntity = () => {
     key: e.node.study_code,
   }));
 
+  const variantStudyFrequencies = (data?.study_frequencies_wgs?.hits?.edges || []).map(
+    (e) => e.node,
+  );
+
+  const variantStudyWithFrequencies = variantStudies.map((vs) => ({
+    ...vs,
+    total: variantStudyFrequencies.find((vf) => vf.study_code === vs.study_code)?.total || {},
+  }));
+
   return (
     <EntityPageWrapper
       pageId="variant-entity-page"
@@ -102,7 +111,7 @@ const VariantEntity = () => {
         <EntityTable
           id={SectionId.FREQUENCIES}
           columns={getFrequenciesItems()}
-          data={variantStudies}
+          data={variantStudyWithFrequencies}
           title={intl.get('entities.variant.frequencies.frequency')}
           header={intl.get('entities.study.CQDGStudies')}
           loading={loading}

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -12,7 +12,7 @@ import {
 import { Space, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useStudy } from 'graphql/studies/actions';
-import { IVariantEntity, IVariantStudyEntity } from 'graphql/variants/models';
+import { IVariantEntity, IVariantStudyEntityWithFrequencies } from 'graphql/variants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
@@ -60,7 +60,8 @@ export const getFrequenciesItems = (): ProColumnType[] => [
     title: intl.get('entities.study.domain'),
     key: 'domain',
     width: '14%',
-    render: (study: IVariantStudyEntity) => study && <StudyDomain study_code={study.study_code} />,
+    render: (study: IVariantStudyEntityWithFrequencies) =>
+      study && <StudyDomain study_code={study.study_code} />,
   },
   {
     title: intl.get('entities.variant.frequencies.participants'),
@@ -75,27 +76,29 @@ export const getFrequenciesItems = (): ProColumnType[] => [
       </Space>
     ),
     key: 'participants',
-    render: (row: IVariantStudyEntity) =>
+    render: (row: IVariantStudyEntityWithFrequencies) =>
       formatQuotientOrElse(row.total?.pc || NaN, row.total?.pn || NaN, TABLE_EMPTY_PLACE_HOLDER),
   },
   {
     title: intl.get('entities.variant.frequencies.frequency'),
     tooltip: intl.get('entities.variant.frequencies.frequencyTooltip'),
     key: 'frequency',
-    render: (row: IVariantStudyEntity) => toExponentialNotation(row.total.af),
+    render: (row: IVariantStudyEntityWithFrequencies) => toExponentialNotation(row.total.af),
   },
   {
     title: intl.get('entities.variant.frequencies.altAlleles'),
     tooltip: intl.get('entities.variant.frequencies.altAllelesTooltip'),
     key: 'alt',
-    render: (row: IVariantStudyEntity) => (row.total?.ac ? numberFormat(row.total.ac) : 0),
+    render: (row: IVariantStudyEntityWithFrequencies) =>
+      row.total?.ac ? numberFormat(row.total.ac) : 0,
     width: '14%',
   },
   {
     title: intl.get('entities.variant.frequencies.homozygotes'),
     tooltip: intl.get('entities.variant.frequencies.homozygotesTooltip'),
     key: 'hom',
-    render: (row: IVariantStudyEntity) => (row.total?.hom ? numberFormat(row.total?.hom) : 0),
+    render: (row: IVariantStudyEntityWithFrequencies) =>
+      row.total?.hom ? numberFormat(row.total?.hom) : 0,
     width: '14%',
   },
 ];

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -12,7 +12,7 @@ import {
 import { Space, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useStudy } from 'graphql/studies/actions';
-import { IVariantEntity, IVariantStudyEntityWithFrequencies } from 'graphql/variants/models';
+import { IVariantEntity, IVariantStudyFrequencies } from 'graphql/variants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
@@ -60,7 +60,7 @@ export const getFrequenciesItems = (): ProColumnType[] => [
     title: intl.get('entities.study.domain'),
     key: 'domain',
     width: '14%',
-    render: (study: IVariantStudyEntityWithFrequencies) =>
+    render: (study: IVariantStudyFrequencies) =>
       study && <StudyDomain study_code={study.study_code} />,
   },
   {
@@ -76,29 +76,27 @@ export const getFrequenciesItems = (): ProColumnType[] => [
       </Space>
     ),
     key: 'participants',
-    render: (row: IVariantStudyEntityWithFrequencies) =>
+    render: (row: IVariantStudyFrequencies) =>
       formatQuotientOrElse(row.total?.pc || NaN, row.total?.pn || NaN, TABLE_EMPTY_PLACE_HOLDER),
   },
   {
     title: intl.get('entities.variant.frequencies.frequency'),
     tooltip: intl.get('entities.variant.frequencies.frequencyTooltip'),
     key: 'frequency',
-    render: (row: IVariantStudyEntityWithFrequencies) => toExponentialNotation(row.total.af),
+    render: (row: IVariantStudyFrequencies) => toExponentialNotation(row.total.af),
   },
   {
     title: intl.get('entities.variant.frequencies.altAlleles'),
     tooltip: intl.get('entities.variant.frequencies.altAllelesTooltip'),
     key: 'alt',
-    render: (row: IVariantStudyEntityWithFrequencies) =>
-      row.total?.ac ? numberFormat(row.total.ac) : 0,
+    render: (row: IVariantStudyFrequencies) => (row.total?.ac ? numberFormat(row.total.ac) : 0),
     width: '14%',
   },
   {
     title: intl.get('entities.variant.frequencies.homozygotes'),
     tooltip: intl.get('entities.variant.frequencies.homozygotesTooltip'),
     key: 'hom',
-    render: (row: IVariantStudyEntityWithFrequencies) =>
-      row.total?.hom ? numberFormat(row.total?.hom) : 0,
+    render: (row: IVariantStudyFrequencies) => (row.total?.hom ? numberFormat(row.total?.hom) : 0),
     width: '14%',
   },
 ];


### PR DESCRIPTION
# FIX: variant entity page bug, mapping change

- closes #[CQDG-533](https://ferlab-crsj.atlassian.net/browse/CQDG-533)

## Description

Variant mapping has changed. The field `total` previously inside the `studies` field is moved into another field called `study_frequencies_wgs`

was:
![image](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/4e334e8b-4bbe-4a8e-b1e5-fe2544b2bd82)

is now:
![Screenshot from 2024-01-12 17-01-34](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/1252af6e-5a11-47d7-90dc-4aec57731f42)

Acceptance Criterias

fix portal accordingly

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
ERROR

### After
![Screenshot from 2024-01-12 17-02-54](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/29788342/a1ff6d24-a0c4-4241-82f4-0e1503dbd62a)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo



[CQDG-533]: https://ferlab-crsj.atlassian.net/browse/CQDG-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ