### PR TITLE
feat: CQDG-572 replace generateLocalTsvReport by fetchTsvReport

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { resetSearchAfterQueryConfig, tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
 import useQueryBuilderState, {
   addQuery,
@@ -33,7 +34,6 @@ import {
 import { extractNcitTissueTitleAndCode } from 'views/DataExploration/utils/helper';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
-import { IProColumnExport } from 'common/types';
 import DownloadSampleDataButton from 'components/reports/DownloadSamplelDataButton';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
@@ -47,7 +47,7 @@ import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
 
-const getDefaultColumns = (): IProColumnExport[] => [
+const getDefaultColumns = (): ProColumnType[] => [
   {
     key: 'sample_id',
     dataIndex: 'sample_id',
@@ -80,7 +80,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
     key: 'participant.participant_id',
     dataIndex: 'participant',
     title: intl.get('screen.dataExploration.tabs.biospecimens.participant_id'),
-    exportValue: (biospecimen: IBiospecimenEntity) => biospecimen?.participant?.participant_id,
     render: (participant: IParticipantEntity) => (
       <Link to={`${STATIC_ROUTES.PARTICIPANTS}/${participant.participant_id}`}>
         {participant.participant_id}
@@ -144,10 +143,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
         </div>
       )),
     },
-    exportValue: (b: IBiospecimenEntity) => {
-      const category = ageCategories.find((cat) => cat.key === b?.age_biospecimen_collection);
-      return category ? `${category.label}: ${category.tooltip}` : b?.age_biospecimen_collection;
-    },
     render: (age_biospecimen_collection: string) => {
       const category = ageCategories.find((cat) => cat.key === age_biospecimen_collection);
       if (!category) return TABLE_EMPTY_PLACE_HOLDER;
@@ -163,10 +158,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
   {
     key: 'files',
     title: intl.get('screen.dataExploration.tabs.biospecimens.files'),
-    exportValue: (biospecimen: IBiospecimenEntity) => {
-      const fileCount = biospecimen?.files?.hits?.total || 0;
-      return `${fileCount}`;
-    },
     render: (biospecimen: IBiospecimenEntity) => {
       const fileCount = biospecimen?.files?.hits?.total || 0;
       return fileCount ? (

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -37,7 +37,7 @@ import { IProColumnExport } from 'common/types';
 import DownloadSampleDataButton from 'components/reports/DownloadSamplelDataButton';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
-import { generateLocalTsvReport } from 'store/report/thunks';
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { formatQuerySortList, scrollToTop } from 'utils/helper';
@@ -320,11 +320,11 @@ const BiospecimenTab = ({ sqon }: IBiospecimenTabProps) => {
           ),
         onTableExportClick: () =>
           dispatch(
-            generateLocalTsvReport({
+            fetchTsvReport({
+              columnStates: userColumns,
+              columns: defaultCols,
               index: INDEXES.BIOSPECIMEN,
-              headers: defaultCols,
-              cols: userColumns,
-              rows: selectedRows?.length ? selectedRows : results.data,
+              sqon: getCurrentSqon(),
             }),
           ),
         extra: [

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -35,7 +35,7 @@ import DownloadFileManifestModal from 'components/reports/DownloadFileManifestMo
 import DownloadRequestAccessModal from 'components/reports/DownloadRequestAccessModal';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
-import { generateLocalTsvReport } from 'store/report/thunks';
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { userHasAccessToFile } from 'utils/dataFiles';
@@ -351,11 +351,11 @@ const DataFilesTab = ({ sqon }: IDataFilesTabProps) => {
           },
           onTableExportClick: () =>
             dispatch(
-              generateLocalTsvReport({
+              fetchTsvReport({
+                columnStates: userColumns,
+                columns: defaultCols,
                 index: INDEXES.FILE,
-                headers: defaultCols,
-                cols: userColumns,
-                rows: selectedRows?.length ? selectedRows : results.data,
+                sqon: getCurrentSqon(),
               }),
             ),
           onColumnSortChange: (newState) =>

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { LockOutlined, SafetyOutlined, UnlockFilled } from '@ant-design/icons';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { resetSearchAfterQueryConfig, tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
 import useQueryBuilderState, {
   addQuery,
@@ -30,7 +31,6 @@ import {
 } from 'views/DataExploration/utils/constant';
 
 import { MAX_ITEMS_QUERY, TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
-import { IProColumnExport } from 'common/types';
 import DownloadFileManifestModal from 'components/reports/DownloadFileManifestModal';
 import DownloadRequestAccessModal from 'components/reports/DownloadRequestAccessModal';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
@@ -47,17 +47,13 @@ import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
 
-const getDefaultColumns = (): IProColumnExport[] => [
+const getDefaultColumns = (): ProColumnType[] => [
   {
     key: 'lock',
     title: intl.get('screen.dataExploration.tabs.datafiles.fileAuthorization'),
     iconTitle: <LockOutlined />,
     tooltip: intl.get('screen.dataExploration.tabs.datafiles.fileAuthorization'),
     align: 'center',
-    exportValue: (file: IFileEntity) => {
-      const hasAccess = userHasAccessToFile(file);
-      return hasAccess ? 'Authorized' : 'Controlled';
-    },
     render: (file: IFileEntity) => {
       const hasAccess = userHasAccessToFile(file);
       return hasAccess ? (
@@ -79,8 +75,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
     dataIndex: 'data_access',
     sorter: { multiple: 1 },
     align: 'center',
-    exportValue: (file: IFileEntity) =>
-      file?.data_access === FileAccessType.REGISTERED ? 'Registered' : 'Controlled',
     render: (data_access: string) =>
       data_access === FileAccessType.REGISTERED ? (
         <Tooltip title={intl.get('screen.dataExploration.tabs.datafiles.registered')}>
@@ -126,7 +120,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
     title: intl.get('screen.dataExploration.tabs.datafiles.strategy'),
     dataIndex: 'sequencing_experiment',
     sorter: { multiple: 1 },
-    exportValue: (row) => row?.sequencing_experiment?.experimental_strategy || '--',
     render: (sequencing_experiment) =>
       sequencing_experiment?.experimental_strategy || TABLE_EMPTY_PLACE_HOLDER,
   },
@@ -146,10 +139,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
   {
     key: 'nb_participants',
     title: intl.get('screen.dataExploration.tabs.datafiles.participants'),
-    exportValue: (file: IFileEntity) => {
-      const participantIds = file?.participants?.hits.edges.map((p) => p.node.participant_id) || [];
-      return `${numberFormat(participantIds.length)}`;
-    },
     render: (file: IFileEntity) => {
       const participantIds = file?.participants?.hits.edges.map((p) => p.node.participant_id) || [];
       return participantIds?.length ? (
@@ -181,10 +170,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
   {
     key: 'nb_biospecimens',
     title: intl.get('screen.dataExploration.tabs.datafiles.biospecimens'),
-    exportValue: (file: IFileEntity) => {
-      const nb_biospecimens = file?.biospecimens?.hits.total || 0;
-      return `${numberFormat(nb_biospecimens)}`;
-    },
     render: (file: IFileEntity) => {
       const nb_biospecimens = file?.biospecimens?.hits.total || 0;
       return nb_biospecimens ? (
@@ -226,7 +211,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
     dataIndex: 'sequencing_experiment',
     sorter: { multiple: 1 },
     defaultHidden: true,
-    exportValue: (file: IFileEntity) => file?.sequencing_experiment?.platform,
     render: (sequencing_experiment) => sequencing_experiment?.platform || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -50,7 +50,7 @@ import { IProColumnExport } from 'common/types';
 import DownloadClinicalDataDropdown from 'components/reports/DownloadClinicalDataDropdown';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
-import { generateLocalTsvReport } from 'store/report/thunks';
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { formatQuerySortList, scrollToTop } from 'utils/helper';
@@ -472,11 +472,11 @@ const ParticipantsTab = ({ sqon }: IParticipantsTabProps) => {
           ),
         onTableExportClick: () =>
           dispatch(
-            generateLocalTsvReport({
+            fetchTsvReport({
+              columnStates: userColumns,
+              columns: defaultCols,
               index: INDEXES.PARTICIPANT,
-              headers: defaultCols,
-              cols: userColumns,
-              rows: selectedRows?.length ? selectedRows : results.data,
+              sqon: getCurrentSqon(),
             }),
           ),
         onSelectAllResultsChange: setSelectedAllResults,

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -6,6 +6,7 @@ import ColorTag, { ColorTagType } from '@ferlab/ui/core/components/ColorTag';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { resetSearchAfterQueryConfig, tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
 import useQueryBuilderState, {
   addQuery,
@@ -46,7 +47,6 @@ import {
 } from 'views/DataExploration/utils/helper';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
-import { IProColumnExport } from 'common/types';
 import DownloadClinicalDataDropdown from 'components/reports/DownloadClinicalDataDropdown';
 import SetsManagementDropdown from 'components/uiKit/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
@@ -60,7 +60,7 @@ import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
 
-const getDefaultColumns = (): IProColumnExport[] => [
+const getDefaultColumns = (): ProColumnType[] => [
   {
     key: 'participant_id',
     title: intl.get('screen.dataExploration.tabs.participants.participant'),
@@ -87,14 +87,10 @@ const getDefaultColumns = (): IProColumnExport[] => [
     render: (sex: string) => <ColorTag type={ColorTagType.Gender} value={capitalize(sex)} />,
   },
   {
-    key: 'mondo_tagged',
+    key: 'mondo_tagged.name',
     title: intl.get('screen.dataExploration.tabs.participants.diagnosis'),
     dataIndex: 'mondo_tagged',
     className: styles.diagnosisCell,
-    exportValue: (participant: IParticipantEntity) => {
-      const names = participant?.mondo_tagged?.hits?.edges.map((p) => p.node.name);
-      return names?.join(', ') || '--';
-    },
     render: (mondo_tagged: ArrangerResultsTree<IMondoTagged>) => {
       const mondoNames = mondo_tagged?.hits?.edges.map((m) => m.node.name);
       if (!mondoNames?.length) return TABLE_EMPTY_PLACE_HOLDER;
@@ -110,9 +106,9 @@ const getDefaultColumns = (): IProColumnExport[] => [
             const mondoInfo = extractMondoTitleAndCode(mondo_id);
             return (
               <div key={id}>
-                {mondoInfo!.title} (MONDO:{' '}
-                <ExternalLink href={`http://purl.obolibrary.org/obo/MONDO_${mondoInfo!.code}`}>
-                  {mondoInfo!.code}
+                {mondoInfo.title} (MONDO:{' '}
+                <ExternalLink href={`http://purl.obolibrary.org/obo/MONDO_${mondoInfo.code}`}>
+                  {mondoInfo.code}
                 </ExternalLink>
                 )
               </div>
@@ -123,13 +119,9 @@ const getDefaultColumns = (): IProColumnExport[] => [
     },
   },
   {
-    key: 'observed_phenotype_tagged',
+    key: 'observed_phenotype_tagged.name',
     title: intl.get('screen.dataExploration.tabs.participants.phenotype'),
     dataIndex: 'observed_phenotype_tagged',
-    exportValue: (participant: IParticipantEntity) => {
-      const names = participant?.observed_phenotype_tagged?.hits?.edges.map((p) => p.node.name);
-      return names?.join(', ') || '--';
-    },
     className: styles.phenotypeCell,
     render: (observed_phenotype_tagged: ArrangerResultsTree<IPhenotype>) => {
       const phenotypeNames = observed_phenotype_tagged?.hits?.edges.map((p) => p.node.name);
@@ -182,10 +174,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
         </div>
       )),
     },
-    exportValue: (participant: IParticipantEntity) => {
-      const category = ageCategories.find((cat) => cat.key === participant?.age_at_recruitment);
-      return category ? `${category.label}: ${category.tooltip}` : participant?.age_at_recruitment;
-    },
     render: (age_at_recruitment) => {
       const category = ageCategories.find((cat) => cat.key === age_at_recruitment);
       if (!category) return TABLE_EMPTY_PLACE_HOLDER;
@@ -201,10 +189,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
   {
     key: 'nb_files',
     title: intl.get('screen.dataExploration.tabs.participants.files'),
-    exportValue: (participant: IParticipantEntity) => {
-      const fileCount = participant?.files?.hits.total || 0;
-      return `${fileCount}` || '--';
-    },
     render: (participant: ITableParticipantEntity) => {
       const fileCount = participant?.files?.hits.total || 0;
       return fileCount ? (
@@ -236,10 +220,6 @@ const getDefaultColumns = (): IProColumnExport[] => [
   {
     key: 'nb_biospecimen',
     title: intl.get('screen.dataExploration.tabs.participants.biospecimen'),
-    exportValue: (participant: IParticipantEntity) => {
-      const nb_biospecimens = participant?.biospecimens?.hits.total || 0;
-      return `${nb_biospecimens}` || '--';
-    },
     render: (participant: ITableParticipantEntity) => {
       const nb_biospecimens = participant?.biospecimens?.hits.total || 0;
       return nb_biospecimens ? (
@@ -277,15 +257,11 @@ const getDefaultColumns = (): IProColumnExport[] => [
     render: (ethnicity) => ethnicity || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'icd_tagged',
+    key: 'icd_tagged.name',
     title: intl.get('screen.dataExploration.tabs.participants.icdTagged'),
     dataIndex: 'icd_tagged',
     defaultHidden: true,
     className: styles.diagnosisCell,
-    exportValue: (participant: IParticipantEntity) => {
-      const names = participant?.icd_tagged?.hits?.edges.map((p) => p.node.name);
-      return names?.join(', ') || '--';
-    },
     render: (icd_tagged: ArrangerResultsTree<IIcd>) => {
       const icdNames = icd_tagged?.hits?.edges.map((m) => m.node.name).filter((n) => n);
       if (!icdNames?.length) return TABLE_EMPTY_PLACE_HOLDER;
@@ -314,15 +290,11 @@ const getDefaultColumns = (): IProColumnExport[] => [
     },
   },
   {
-    key: 'mondo_tagged__source_text',
+    key: 'mondo_tagged.source_text',
     title: intl.get('screen.dataExploration.tabs.participants.diagnosisSourceText'),
     dataIndex: 'mondo_tagged',
     defaultHidden: true,
     className: styles.diagnosisCell,
-    exportValue: (participant: IParticipantEntity) => {
-      const sourceTexts = participant?.mondo_tagged?.hits?.edges.map((m) => m.node.source_text);
-      return sourceTexts?.join(', ') || '--';
-    },
     render: (mondo_tagged: ArrangerResultsTree<IMondoTagged>) => {
       const sourceTexts = mondo_tagged?.hits?.edges.map((m) => m.node.source_text);
       if (!sourceTexts?.length) return TABLE_EMPTY_PLACE_HOLDER;


### PR DESCRIPTION
# feat: CQDG-572 replace generateLocalTsvReport by fetchTsvReport

- closes #TICKET_NUMBER

## Description

`generateLocalTsvReport` permettait d'ajouter un field `exportValue` sur lequel je travaillais la donnée pour chaque colonne du tableau afin de l'afficher sur le TSV téléchargé.
On repasse par le fetchTsv qui call Arranger pour pouvoir télécharger toutes les données des tableaux paginés.
Les données sur le TSV sont directement issues d'ES  



https://ferlab-crsj.atlassian.net/browse/CQDG-572

