### PR TITLE
feat: CQDG-566 refonte text and link in savedfilters n savedsets

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -863,6 +863,7 @@ const en = {
             'We are currently unable to connect to this service. Please refresh the page and try again. If the problem persists, please',
           contactSupport: 'contact support',
           pleaseRefresh: 'Please refresh and try again or ',
+          failedFetch: 'Failed to fetch filters saved',
         },
         savedFilters: {
           title: 'Saved Filters',
@@ -871,9 +872,6 @@ const en = {
             'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the ',
           noSaved:
             'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the ',
-          lastSaved: 'Last saved: {date} ago',
-          variants: 'Variants',
-          failedFetch: 'Failed to fetch filters saved',
         },
         savedSets: {
           title: 'Saved Sets',
@@ -882,9 +880,8 @@ const en = {
             'A saved set is a set of one or more entity IDs that can be saved and revisited for later use without having to manually reselect entity IDs. You can create Participant, Biospecimen, and File saved sets at the top of the table of results in the ',
           noSaved:
             'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the ',
-          lastSaved: 'Last saved: {date} ago',
-          failedFetch: 'Failed to fetch sets saved',
         },
+        lastSaved: 'Last saved: {date} ago',
         and: ' and ',
         pages: ' pages.',
       },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -868,12 +868,10 @@ const en = {
           title: 'Saved Filters',
           popoverTitle: 'Managing Saved Filters',
           popoverContent:
-            'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
-          popoverContentLink: 'Data Exploration page',
+            'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the ',
           noSaved:
-            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
+            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the ',
           lastSaved: 'Last saved: {date} ago',
-          dataExploration: 'Data Exploration',
           variants: 'Variants',
           failedFetch: 'Failed to fetch filters saved',
         },
@@ -881,13 +879,14 @@ const en = {
           title: 'Saved Sets',
           popoverTitle: 'Managing Saved Sets',
           popoverContent:
-            'A saved set is a set of one or more entity IDs that can be saved and revisited for later use without having to manually reselect entity IDs. You can create Participant, Biospecimen, and File saved sets at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
-          popoverContentLink: 'Data Exploration page',
+            'A saved set is a set of one or more entity IDs that can be saved and revisited for later use without having to manually reselect entity IDs. You can create Participant, Biospecimen, and File saved sets at the top of the table of results in the ',
           noSaved:
-            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
+            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the ',
           lastSaved: 'Last saved: {date} ago',
           failedFetch: 'Failed to fetch sets saved',
         },
+        and: ' and ',
+        pages: ' pages.',
       },
     },
     variants: {
@@ -920,6 +919,7 @@ const en = {
     },
     dataExploration: {
       title: 'Data Exploration',
+      dataExploration: 'Data Exploration',
       sidemenu: {
         participant: 'Participant',
         biospecimen: 'Biospecimen',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -888,6 +888,7 @@ const en = {
     },
     variants: {
       title: 'Variants Exploration',
+      variantsExploration: 'Variants Exploration',
       noDataVariant: 'No data available for this variant',
       sidemenu: {
         participant: 'Participant',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -887,7 +887,6 @@ const en = {
       },
     },
     variants: {
-      title: 'Variants Exploration',
       variantsExploration: 'Variants Exploration',
       noDataVariant: 'No data available for this variant',
       sidemenu: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -892,6 +892,7 @@ const fr = {
     },
     variants: {
       title: 'Exploration de variants',
+      variantsExploration: 'Exploration des variants',
       noDataVariant: 'Aucune donnée disponible pour ce variant',
       sidemenu: {
         participant: 'Participant',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -872,12 +872,10 @@ const fr = {
           title: 'Filtres enregistrés',
           popoverTitle: 'Gestion des filtres enregistrés',
           popoverContent:
-            'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à une requête de recherche. Ils peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les filtres dans la barre latérale. Vous pouvez créer des filtres enregistrés à l\'aide de l\'outil de gestion des requêtes au-dessus du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
-          popoverContentLink: 'page Exploration des données',
+            "Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à une requête de recherche. Ils peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les filtres dans la barre latérale. Vous pouvez créer des filtres enregistrés à l'aide de l'outil de gestion des requêtes au-dessus du tableau des résultats dans les pages ",
           noSaved:
-            'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à un ensemble de données. Enregistrez votre premier filtre depuis la barre de requêtes en haut des pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
+            'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à un ensemble de données. Enregistrez votre premier filtre depuis la barre de requêtes en haut des pages ',
           lastSaved: 'Dernier enregistrement : il y a {date}',
-          dataExploration: 'Exploration des données',
           variants: 'Variants',
           failedFetch: 'Échec de la récupération des filtres enregistrés',
         },
@@ -885,13 +883,14 @@ const fr = {
           title: 'Ensembles enregistrés',
           popoverTitle: 'Gestion des ensembles enregistrés',
           popoverContent:
-            'Un ensemble enregistré est un ensemble d\'un ou plusieurs ID d\'entité qui peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les ID d\'entité. Vous pouvez créer des ensembles enregistrés de participants, d\'échantillons biologiques et de fichiers en haut du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
-          popoverContentLink: 'page Exploration des données',
+            "Un ensemble enregistré est un ensemble d'un ou plusieurs ID d'entité qui peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les ID d'entité. Vous pouvez créer des ensembles enregistrés de participants, d'échantillons biologiques et de fichiers en haut du tableau des résultats dans les pages ",
           noSaved:
-            'Un ensemble enregistré est un ensemble d\'entités qui peuvent être enregistrées et utilisées ultérieurement. Enregistrez votre premier ensemble en haut du tableau des résultats dans les pages <a href="{dataExploHref}" style="text-decoration: underline;">Exploration des données</a> et <a href="{variantsHref}" style="text-decoration: underline;">Exploration des variants</a>.',
+            "Un ensemble enregistré est un ensemble d'entités qui peuvent être enregistrées et utilisées ultérieurement. Enregistrez votre premier ensemble en haut du tableau des résultats dans les pages ",
           lastSaved: 'Dernier enregistrement : il y a {date}',
           failedFetch: 'Échec de la récupération des ensembles enregistrés',
         },
+        and: ' et ',
+        pages: '.',
       },
     },
     variants: {
@@ -924,6 +923,7 @@ const fr = {
     },
     dataExploration: {
       title: 'Exploration',
+      dataExploration: 'Exploration des données',
       sidemenu: {
         participant: 'Participant',
         biospecimen: 'Biospécimen',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -867,6 +867,7 @@ const fr = {
             'Nous ne sommes actuellement pas en mesure de nous connecter à ce service. Veuillez actualiser la page et réessayer. Si le problème persiste, veuillez',
           contactSupport: 'contactez le support',
           pleaseRefresh: 'Veuillez actualiser et réessayer ou ',
+          failedFetch: 'Échec de la récupération des filtres enregistrés',
         },
         savedFilters: {
           title: 'Filtres enregistrés',
@@ -875,9 +876,6 @@ const fr = {
             "Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à une requête de recherche. Ils peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les filtres dans la barre latérale. Vous pouvez créer des filtres enregistrés à l'aide de l'outil de gestion des requêtes au-dessus du tableau des résultats dans les pages ",
           noSaved:
             'Un filtre enregistré est une requête virtuelle créée en appliquant un ou plusieurs filtres à un ensemble de données. Enregistrez votre premier filtre depuis la barre de requêtes en haut des pages ',
-          lastSaved: 'Dernier enregistrement : il y a {date}',
-          variants: 'Variants',
-          failedFetch: 'Échec de la récupération des filtres enregistrés',
         },
         savedSets: {
           title: 'Ensembles enregistrés',
@@ -886,9 +884,8 @@ const fr = {
             "Un ensemble enregistré est un ensemble d'un ou plusieurs ID d'entité qui peuvent être enregistrés et revisités pour une utilisation ultérieure sans avoir à resélectionner manuellement les ID d'entité. Vous pouvez créer des ensembles enregistrés de participants, d'échantillons biologiques et de fichiers en haut du tableau des résultats dans les pages ",
           noSaved:
             "Un ensemble enregistré est un ensemble d'entités qui peuvent être enregistrées et utilisées ultérieurement. Enregistrez votre premier ensemble en haut du tableau des résultats dans les pages ",
-          lastSaved: 'Dernier enregistrement : il y a {date}',
-          failedFetch: 'Échec de la récupération des ensembles enregistrés',
         },
+        lastSaved: 'Dernier enregistrement : il y a {date}',
         and: ' et ',
         pages: '.',
       },

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -891,7 +891,6 @@ const fr = {
       },
     },
     variants: {
-      title: 'Exploration de variants',
       variantsExploration: 'Exploration des variants',
       noDataVariant: 'Aucune donnée disponible pour ce variant',
       sidemenu: {

--- a/src/style/themes/cqdg/antd-cqdg-theme.less
+++ b/src/style/themes/cqdg/antd-cqdg-theme.less
@@ -70,3 +70,12 @@
 
 // LAYOUT
 @layout-body-background: @gray-3;
+
+// a (antd force text-decoration: none)
+.ant-typography a, .ant-descriptions a {
+  text-decoration: underline;
+}
+
+.ant-typography a:hover, .ant-descriptions a:hover {
+  text-decoration: none;
+}

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -197,7 +197,7 @@ export const getQueryBuilderDictionary = (
     manageFilters: {
       modalTitle: intl.get('components.querybuilder.header.myFiltersDropdown.manageMyFilter'),
       okText: intl.get('components.querybuilder.header.myFiltersDropdown.okText'),
-      lastSavedAt: intl.get('screen.dashboard.cards.savedFilters.lastSaved'),
+      lastSavedAt: intl.get('screen.dashboard.cards.lastSaved'),
     },
     duplicateFilterTitleSuffix: intl.get(
       'components.querybuilder.header.duplicateFilterTitleSuffix',

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/ListItem/index.tsx
@@ -50,7 +50,7 @@ const ListItem = ({ data }: IListItemProps) => {
           });
         }}
         title={data.title}
-        description={intl.get('screen.dashboard.cards.savedFilters.lastSaved', {
+        description={intl.get('screen.dashboard.cards.lastSaved', {
           date: formatDistance(new Date(), new Date(data.updated_date)),
         })}
       />

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -1,4 +1,5 @@
 import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
 import { FileSearchOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
@@ -21,6 +22,7 @@ import styles from './index.module.scss';
 
 const { Text } = Typography;
 
+// @ts-ignore
 const getItemList = (
   savedFilters: TUserSavedFilter[],
   fetchingError: boolean,
@@ -46,10 +48,18 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.getHTML('screen.dashboard.cards.savedFilters.noSaved', {
-            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-            variantsHref: STATIC_ROUTES.VARIANTS,
-          })}
+          // @ts-ignore cuz the type description is a string
+          description={
+            <>
+              {intl.get('screen.dashboard.cards.savedFilters.noSaved')}
+              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                {intl.get('screen.dataExploration.dataExploration')}
+              </Link>
+              {intl.get('screen.dashboard.cards.and')}
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+              {intl.get('screen.dashboard.cards.pages')}
+            </>
+          }
         />
       ),
     }}
@@ -74,8 +84,7 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
       label: (
         <div data-cy="Tab_DataExploration">
           <FileSearchOutlined />
-          {intl.get('screen.dashboard.cards.savedFilters.dataExploration')} (
-          {dataExplorationFilters.length})
+          {intl.get('screen.dataExploration.dataExploration')} ({dataExplorationFilters.length})
         </div>
       ),
       key: SavedFilterTag.DataExplorationPage,
@@ -107,10 +116,13 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedFilters.popoverTitle'),
             content: (
               <Text>
-                {intl.getHTML('screen.dashboard.cards.savedFilters.popoverContent', {
-                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-                  variantsHref: STATIC_ROUTES.VARIANTS,
-                })}
+                {intl.get('screen.dashboard.cards.savedFilters.popoverContent')}
+                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                  {intl.get('screen.dataExploration.dataExploration')}
+                </Link>
+                {intl.get('screen.dashboard.cards.and')}
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+                {intl.get('screen.dashboard.cards.pages')}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -34,7 +34,7 @@ const getItemList = (
     locale={{
       emptyText: fetchingError ? (
         <CardErrorPlaceholder
-          title={intl.get('screen.dashboard.cards.savedFilters.failedFetch')}
+          title={intl.get('screen.dashboard.cards.error.failedFetch')}
           subTitle={
             <Text>
               {intl.get('screen.dashboard.cards.pleaseRefresh')}
@@ -94,7 +94,7 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
       label: (
         <div data-cy="Tab_Variants">
           <LineStyleIcon height={16} width={16} className={styles.iconSvg} />
-          {intl.get('screen.dashboard.cards.savedFilters.variants')} ({variantFilters.length})
+          {intl.get('entities.variant.variants')} ({variantFilters.length})
         </div>
       ),
       key: SavedFilterTag.VariantsExplorationPage,

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -22,7 +22,6 @@ import styles from './index.module.scss';
 
 const { Text } = Typography;
 
-// @ts-ignore
 const getItemList = (
   savedFilters: TUserSavedFilter[],
   fetchingError: boolean,
@@ -56,7 +55,9 @@ const getItemList = (
                 {intl.get('screen.dataExploration.dataExploration')}
               </Link>
               {intl.get('screen.dashboard.cards.and')}
-              <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                {intl.get('screen.variants.variantsExploration')}
+              </Link>
               {intl.get('screen.dashboard.cards.pages')}
             </>
           }
@@ -121,7 +122,9 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
                   {intl.get('screen.dataExploration.dataExploration')}
                 </Link>
                 {intl.get('screen.dashboard.cards.and')}
-                <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                  {intl.get('screen.variants.variantsExploration')}
+                </Link>
                 {intl.get('screen.dashboard.cards.pages')}
               </Text>
             ),

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
@@ -101,7 +101,7 @@ const ListItem = ({ data, icon }: IListItemProps) => {
           history.push(redirectToPage(data.setType));
         }}
         title={data.tag}
-        description={intl.get('screen.dashboard.cards.savedFilters.lastSaved', {
+        description={intl.get('screen.dashboard.cards.lastSaved', {
           date: formatDistance(new Date(), new Date(data.updated_date)),
         })}
       />

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -1,6 +1,6 @@
 @import 'src/style/themes/cqdg/colors';
 
-.savedFiltersList {
+.savedSetsList {
   height: 100%;
   overflow: auto;
   min-height: 200px;

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -36,7 +36,7 @@ const getItemList = (
     locale={{
       emptyText: fetchingError ? (
         <CardErrorPlaceholder
-          title={intl.get('screen.dashboard.cards.savedSets.failedFetch')}
+          title={intl.get('screen.dashboard.cards.error.failedFetch')}
           subTitle={
             <Text>
               {intl.get('screen.dashboard.cards.pleaseRefresh')}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
 import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
@@ -30,7 +31,7 @@ const getItemList = (
   icon: ReactElement,
 ) => (
   <List<IUserSetOutput>
-    className={styles.savedFiltersList}
+    className={styles.savedSetsList}
     bordered
     locale={{
       emptyText: fetchingError ? (
@@ -49,10 +50,18 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.getHTML('screen.dashboard.cards.savedSets.noSaved', {
-            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-            variantsHref: STATIC_ROUTES.VARIANTS,
-          })}
+          // @ts-ignore cuz the type description is a string
+          description={
+            <>
+              {intl.get('screen.dashboard.cards.savedSets.noSaved')}
+              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                {intl.get('screen.dataExploration.dataExploration')}
+              </Link>
+              {intl.get('screen.dashboard.cards.and')}
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+              {intl.get('screen.dashboard.cards.pages')}
+            </>
+          }
         />
       ),
     }}
@@ -61,7 +70,6 @@ const getItemList = (
     renderItem={(item) => <ListItem data={item} icon={icon} />}
   />
 );
-
 const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
   const { savedSets, isLoading, fetchingError } = useSavedSet();
 
@@ -150,10 +158,13 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedSets.popoverTitle'),
             content: (
               <Text>
-                {intl.getHTML('screen.dashboard.cards.savedSets.popoverContent', {
-                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-                  variantsHref: STATIC_ROUTES.VARIANTS,
-                })}
+                {intl.get('screen.dashboard.cards.savedSets.popoverContent')}
+                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                  {intl.get('screen.dataExploration.dataExploration')}
+                </Link>
+                {intl.get('screen.dashboard.cards.and')}
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+                {intl.get('screen.dashboard.cards.pages')}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -58,7 +58,9 @@ const getItemList = (
                 {intl.get('screen.dataExploration.dataExploration')}
               </Link>
               {intl.get('screen.dashboard.cards.and')}
-              <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                {intl.get('screen.variants.variantsExploration')}
+              </Link>
               {intl.get('screen.dashboard.cards.pages')}
             </>
           }
@@ -163,7 +165,9 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
                   {intl.get('screen.dataExploration.dataExploration')}
                 </Link>
                 {intl.get('screen.dashboard.cards.and')}
-                <Link to={`${STATIC_ROUTES.VARIANTS}`}>{intl.get('screen.variants.title')}</Link>
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                  {intl.get('screen.variants.variantsExploration')}
+                </Link>
                 {intl.get('screen.dashboard.cards.pages')}
               </Text>
             ),

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -139,7 +139,7 @@ const PageContent = ({ variantMapping }: IPageContentProps) => {
     <Space direction="vertical" size={24} className={styles.variantsPageContent}>
       <div className={styles.pageHeader}>
         <Typography.Title className={styles.pageHeaderTitle} level={1} data-cy="Title_Variants">
-          {intl.get('screen.variants.title')}
+          {intl.get('screen.variants.variantsExploration')}
         </Typography.Title>
       </div>
 


### PR DESCRIPTION
# [feat: CQDG-566 refonte text in savedfilters n savedsets](https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/commit/c90b00d8de8ff6323996ff63bbf0db1c02286487)

- closes #TICKET_NUMBER

## Description

Le but est d'utiliser des Link a la place des a pour rester dans le context de l'app React sans faire de hard refresh a la redirection.

https://ferlab-crsj.atlassian.net/browse/CQDG-566

<img width="645" alt="image" src="https://github.com/Ferlab-Ste-Justine/cqdg-portal-ui/assets/15524246/d85f98bb-b840-4b18-bc9a-80f38a238f08">


