### PR TITLE
fix: CQDG-830 use pattern for validate the name of Sets and Filters

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -15,6 +15,8 @@ export const FILTER_ID_QUERY_PARAM_KEY = 'filterId';
 export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
 
 export const MAX_TITLE_LENGTH = 200;
+// This regex needs to match the one set in Users-Api:
+export const SET_FILTER_NAME_REGEX = /^[\w\s()\-_,.|:'[\]]+$/iu;
 
 export const MAX_ITEMS_QUERY = Number(
   EnvironmentVariables.configFor('ES_MAX_ITEMS_QUERY') || 10000,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -762,6 +762,7 @@ const en = {
           description: 'You are about to delete all your queries. They will be lost forever.',
         },
       },
+      pattern: 'Permitted characters: ((A-Z, a-z, 0-9) ()[]-_:|.,)',
     },
     savedSets: {
       modal: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -762,7 +762,7 @@ const en = {
           description: 'You are about to delete all your queries. They will be lost forever.',
         },
       },
-      pattern: 'Permitted characters: ((A-Z, a-z, 0-9) ()[]-_:|.,)',
+      pattern: 'Permitted characters: A-Z a-z 0-9 ()[]-_:|.,',
     },
     savedSets: {
       modal: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -769,6 +769,7 @@ const fr = {
             'Vous êtes sur le point de supprimer toutes vos requêtes. Ils seront perdus à jamais.',
         },
       },
+      pattern: 'Caractères permis: ((A-Z, a-z, 0-9) () [] - _ : | . ,)',
     },
     savedSets: {
       modal: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -769,7 +769,7 @@ const fr = {
             'Vous êtes sur le point de supprimer toutes vos requêtes. Ils seront perdus à jamais.',
         },
       },
-      pattern: 'Caractères permis: ((A-Z, a-z, 0-9) () [] - _ : | . ,)',
+      pattern: 'Caractères permis : A-Z a-z 0-9 ()[]-_:|,.',
     },
     savedSets: {
       modal: {

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -9,6 +9,8 @@ import { ageCategoriesKeyLabel } from 'graphql/participants/models';
 
 import { IUserSetOutput } from 'services/api/savedSet/models';
 
+import { SET_FILTER_NAME_REGEX } from '../common/constants';
+
 export const getEntityConsequenceDictionary = () => ({
   consequence: intl.get('entities.variant.consequences.consequence'),
   impactTag: {
@@ -161,6 +163,10 @@ export const getQueryBuilderDictionary = (
     form: {
       error: {
         fieldRequired: intl.get('global.forms.errors.requiredField'),
+      },
+      pattern: {
+        message: intl.get('components.querybuilder.pattern'),
+        regex: SET_FILTER_NAME_REGEX,
       },
     },
     popupConfirm: {

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/EditModal/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/EditModal/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { WarningFilled } from '@ant-design/icons';
 import { Form, Input, Modal } from 'antd';
 
-import { MAX_TITLE_LENGTH } from 'common/constants';
+import { MAX_TITLE_LENGTH, SET_FILTER_NAME_REGEX } from 'common/constants';
 import { TUserSavedFilter } from 'services/api/savedFilter/models';
 import { updateSavedFilter } from 'store/savedFilter/thunks';
 
@@ -71,6 +71,16 @@ const EditModal = ({ visible = false, onCancel, filter }: OwnProps) => {
                   type: 'string',
                   required: true,
                   message: intl.get('global.forms.errors.requiredField'),
+                  validateTrigger: 'onSubmit',
+                },
+                {
+                  type: 'string',
+                  message: (
+                    <span>
+                      <WarningFilled /> {intl.get('components.querybuilder.pattern')}
+                    </span>
+                  ),
+                  pattern: SET_FILTER_NAME_REGEX,
                   validateTrigger: 'onSubmit',
                 },
               ]}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
@@ -6,7 +6,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { Form, Input, Modal } from 'antd';
 import { Store } from 'antd/lib/form/interface';
 
-import { MAX_TITLE_LENGTH } from 'common/constants';
+import { MAX_TITLE_LENGTH, SET_FILTER_NAME_REGEX } from 'common/constants';
 import filtersToName from 'common/sqonToName';
 import { SetActionType } from 'components/uiKit/SetsManagementDropdown';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
@@ -179,6 +179,16 @@ const CreateEditModal = ({
               type: 'string',
               required: true,
               message: intl.get('global.forms.errors.requiredField'),
+              validateTrigger: 'onSubmit',
+            },
+            {
+              type: 'string',
+              message: (
+                <span>
+                  <WarningFilled /> {intl.get('components.querybuilder.pattern')}
+                </span>
+              ),
+              pattern: SET_FILTER_NAME_REGEX,
               validateTrigger: 'onSubmit',
             },
           ]}

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -36,7 +36,7 @@ import {
   TAB_IDS,
 } from 'views/DataExploration/utils/constant';
 
-import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
+import { MAX_TITLE_LENGTH, SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
 import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
 import { SavedFilterTag } from 'services/api/savedFilter/models';
@@ -260,6 +260,7 @@ const PageContent = ({
           onSaveFilter: handleOnSaveFilter,
           onDeleteFilter: handleOnDeleteFilter,
           onSetAsFavorite: handleOnSaveAsFavorite,
+          maxNameCapSavedQuery: MAX_TITLE_LENGTH,
         }}
         facetFilterConfig={{
           enable: true,


### PR DESCRIPTION
# FIX: Save Sets / Filters display message restricting characters

- closes [#CQDG-830](https://ferlab-crsj.atlassian.net/browse/CQDG-830)

see: https://portal-ui-cqdg-830.qa.juno.cqdg.ferlab.bio/data-exploration

## Description

The backend Users-api does not allow all characters used in naming Sets or Filters.

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot

### Before

### After
![Screenshot from 2024-08-27 09-21-17](https://github.com/user-attachments/assets/2cfc9e1e-d712-48e4-8ec9-a3b8916f931f)

![Screenshot from 2024-08-27 09-22-06](https://github.com/user-attachments/assets/400b007c-da94-4c1b-9adf-4a9c3a0fef52)

![Screenshot from 2024-08-27 09-22-45](https://github.com/user-attachments/assets/f485b7a9-a794-4b7c-9648-d29ac18ed141)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

