### PR TITLE
feat: CQDG-1174 protect no sequencing_experiment on getFilesInfoByKey

### DIFF
--- a/src/views/ParticipantEntity/utils/getFilesColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getFilesColumns.tsx
@@ -44,11 +44,9 @@ export const getFilesInfoByKey = (files: IFileEntity[], key: string, participant
   const filesInfosData: IFileInfoByType[] = [];
   for (const file of files) {
     // @ts-ignore
-    const valueOfKey: string = file.sequencing_experiment[key];
-    const filesFound = files.filter(
-      // @ts-ignore
-      ({ sequencing_experiment }) => sequencing_experiment[key] === valueOfKey,
-    );
+    const valueOfKey = file.sequencing_experiment?.[key];
+    // @ts-ignore
+    const filesFound = files.filter((f) => f?.sequencing_experiment?.[key] === valueOfKey);
     if (!filesInfosData.find((file) => file.value === valueOfKey)) {
       filesInfosData.push({
         key: valueOfKey,


### PR DESCRIPTION
# feat: protect no sequencing_experiment on getFilesInfoByKey

- Closes CQDG-1174

## Description
<!-- Add a description of the changes proposed in the pull request -->

## Acceptance Criterias
<!-- List all acceptance criteria from the ticket -->

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1174)
- [Design](https://)
- [Ferlease](https://)

## Extra Validation
- [ ] Dev QA on ferlease
- [ ] Reviewer QA on ferlease 
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
<img width="432" height="544" alt="image" src="https://github.com/user-attachments/assets/469b16e9-fcc2-4689-b255-41fe47aca636" />
<img width="1176" height="476" alt="image" src="https://github.com/user-attachments/assets/5ae65291-5321-404b-a6bf-2231d11c1d05" />
