### PR TITLE
fix: CQDG-1196 add facets for new biospecimen fields

### DIFF
--- a/cypress/e2e/Facettes/PageDataExploration_2.cy.ts
+++ b/cypress/e2e/Facettes/PageDataExploration_2.cy.ts
@@ -63,8 +63,38 @@ describe('Page Data Exploration (Biospecimens) - Filtrer avec les facettes', () 
     cy.validateFacetRank(1, 'Tissue');
   });
 
+  it('Cancer Tissue Type - Normal Tissue Sample (NCIT:C162623)', () => {
+    cy.validateFacetFilter('Cancer Tissue Type', 'Normal Tissue Sample (NCIT:C162623)', 'Normal Tissue Sample (NCIT:C162623)', /^9$/);
+    cy.validateFacetRank(2, 'Cancer Tissue Type');
+  });
+
   it('Age at Biospecimen Collection - Congenital', () => {
     cy.validateFacetFilter('Age at Biospecimen Collection', 'Congenital', 'B-congenital', /^2$/);
-    cy.validateFacetRank(2, 'Age at Biospecimen Collection');
+    cy.validateFacetRank(3, 'Age at Biospecimen Collection');
+  });
+
+  it('Tumor Status - Normal', () => {
+    cy.validateFacetFilter('Tumor Status', 'Normal', 'Normal', /^9$/);
+    cy.validateFacetRank(4, 'Tumor Status');
+  });
+
+  it('Tumor Type (NCIt) - Derived Cell Line (NCIT:C156445)', () => {
+    cy.validateFacetFilter('Tumor Type (NCIt)', 'Derived Cell Line (NCIT:C156445)', 'Derived Cell Line (NCIT:C156445)', /^4$/);
+    cy.validateFacetRank(5, 'Tumor Type (NCIt)');
+  });
+
+  it('Tumor Type (Source Text) - Histological Type Source Text', () => {
+    cy.validateFacetFilter('Tumor Type (Source Text)', 'Histological Type Source Text', 'histological_type_source_text', /^9$/);
+    cy.validateFacetRank(6, 'Tumor Type (Source Text)');
+  });
+
+  it('Tumor Location (NCIt) - Derived Cell Line (NCIT:C156445)', () => {
+    cy.validateFacetFilter('Tumor Location (NCIt)', 'Derived Cell Line (NCIT:C156445)', 'Derived Cell Line (NCIT:C156445)', /^2$/);
+    cy.validateFacetRank(7, 'Tumor Location (NCIt)');
+  });
+
+  it('Tumor Location (Source Text) - Anatomic Location Source Text', () => {
+    cy.validateFacetFilter('Tumor Location (Source Text)', 'Anatomic Location Source Text', 'anatomic_location_source_text', /^9$/);
+    cy.validateFacetRank(8, 'Tumor Location (Source Text)');
   });
 });

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -70,6 +70,16 @@ const en = {
       biospecimen_id: 'Biospecimen ID',
       age: 'Age',
       age_biospecimen_collection: 'Age at Biospecimen Collection',
+      cancer_biospecimen_type: 'Cancer Tissue Type',
+      tumor_normal_designation: 'Tumor Status',
+      tumor_histological_type: {
+        display: 'Tumor Type (NCIt)',
+        text: 'Tumor Type (Source Text)',
+      },
+      cancer_anatomic_location: {
+        display: 'Tumor Location (NCIt)',
+        text: 'Tumor Location (Source Text)',
+      },
     },
     participant: {
       participant_id: 'Participant ID',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -70,6 +70,16 @@ const fr = {
       biospecimen_id: 'ID biospécimen',
       age: 'Âge',
       age_biospecimen_collection: 'Âge au prélèvement du biospécimen',
+      cancer_biospecimen_type: 'Type de tissu cancéreux',
+      tumor_normal_designation: 'Statut de la tumeur',
+      tumor_histological_type: {
+        display: 'Type de tumeur (NCIt)',
+        text: 'Type de tumeur (texte source)',
+      },
+      cancer_anatomic_location: {
+        display: 'Emplacement de la tumeur (NCIt)',
+        text: 'Emplacement de la tumeur (texte source)',
+      },
     },
     participant: {
       participant_id: 'ID participant',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -404,6 +404,16 @@ export const getFacetsDictionary = () => ({
   sample_type: intl.get('entities.biospecimen.sample_type'),
   biospecimen_tissue_source: intl.get('entities.biospecimen.biospecimen_tissue_source'),
   age_biospecimen_collection: intl.get('entities.biospecimen.age_biospecimen_collection'),
+  cancer_biospecimen_type: intl.get('entities.biospecimen.cancer_biospecimen_type'),
+  tumor_normal_designation: intl.get('entities.biospecimen.tumor_normal_designation'),
+  tumor_histological_type: {
+    display: intl.get('entities.biospecimen.tumor_histological_type.display'),
+    text: intl.get('entities.biospecimen.tumor_histological_type.text'),
+  },
+  cancer_anatomic_location: {
+    display: intl.get('entities.biospecimen.cancer_anatomic_location.display'),
+    text: intl.get('entities.biospecimen.cancer_anatomic_location.text'),
+  },
   biospecimens: {
     biospecimen_tissue_source: intl.get('entities.biospecimen.biospecimen_tissue_source'),
     age_biospecimen_collection: intl.get('entities.biospecimen.age_biospecimen_collection'),

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -145,7 +145,17 @@ const getFilterGroups = (type: FilterTypes) => {
         ],
         groups: [
           {
-            facets: ['sample_type', 'biospecimen_tissue_source', 'age_biospecimen_collection'],
+            facets: [
+              'sample_type',
+              'biospecimen_tissue_source',
+              'cancer_biospecimen_type',
+              'age_biospecimen_collection',
+              'tumor_normal_designation',
+              'tumor_histological_type__display',
+              'tumor_histological_type__text',
+              'cancer_anatomic_location__display',
+              'cancer_anatomic_location__text',
+            ],
           },
         ],
       };


### PR DESCRIPTION
# fix: add facets for new biospecimen fields

- Closes CQDG-1196

## Description
Dans l’explorateur de données ajouter les facettes suivantes sous la section Biospécimen.

- Type de tissu cancéreux
- Statut de la tumeur
- Type de tumeur (NCIt)
- Type de tumeur (texte source)
- Emplacement de la tumeur (NCIt)
- Emplacement de la tumeur (texte source)Statut de la tumeur

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1196)
- [Design](https://)
- [Ferlease](https://portal-ui-cqdg-1196.qa.juno.cqdg.ferlab.bio/)

## Extra Validation
- [ ] Dev QA on ferlease
- [ ] Reviewer QA on ferlease 
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
<img width="358" height="680" alt="Screenshot from 2025-10-16 08-35-14" src="https://github.com/user-attachments/assets/c3779c0b-3c1f-4cc4-a91a-f924281d6a49" />

### After
<img width="358" height="680" alt="Screenshot from 2025-10-16 08-34-18" src="https://github.com/user-attachments/assets/b08ce0b9-a7b7-4dc6-9aa2-edd3b3c7a4de" />

## QA
### Steps to validate
<!-- Add step by step instructions to test this PR -->
1. 
2. 

## Mention
<!-- @ mention any relevant teammates -->