### PR TITLE
feat(text): CQDG-1246 update radiant text and study summary tooltip

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -26,6 +26,8 @@ const en = {
       name: 'Name',
       keywords: 'Keywords',
       description: 'Description',
+      restrictedTooltip:
+        'The data of this study is not accessible for exploration since it has not yet been harmonized to the CQDG data model.',
       restrictedTitle: 'Restricted Study',
       restrictedContent: 'The data of this study is not accessible for exploration.',
       restrictedContact:
@@ -993,9 +995,9 @@ const en = {
       },
       cards: {
         radiant: {
-          title: 'A new benchmark in precision medicine.',
+          title: 'A new standard in precision medicine.',
           description:
-            'The CQDG is pleased to offer its users Radiant, a secure platform that enables real-time exploration and interpretation of individual genomes in relation to patients’ clinical data, with the goal of accelerating molecular diagnosis and advancing precision medicine research.',
+            "The CQDG is pleased to introduce Radiant, a secure platform that enables real-time exploration and interpretation of individual genomes in conjunction with patients' clinical data, with the aim of accelerating molecular diagnoses and advancing research in precision medicine.",
           tag: 'Coming soon',
         },
         stats: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -26,6 +26,8 @@ const fr = {
       name: 'Nom',
       keywords: 'Mots-clés',
       description: 'Description',
+      restrictedTooltip:
+        "Les données de cette étude ne sont pas accessibles puisqu'elles n'ont pas encore été harmonisées au modèle de données du CQDG.",
       restrictedTitle: 'Étude restreinte',
       restrictedContent: "Les données de cette étude ne sont pas accessibles à l'exploration.",
       restrictedContact:
@@ -1002,7 +1004,7 @@ const fr = {
         radiant: {
           title: 'Une nouvelle référence en médecine de précision.',
           description:
-            'Le CQDG est heureux d’offrir à ses utilisateurs Radiant, une plateforme sécurisée permettant l’exploration et l’interprétation en temps réel des génomes individuels en lien avec les données cliniques des patients, afin d’accélérer le diagnostic moléculaire et de faire progresser la recherche en médecine de précision.',
+            'Le CQDG est heureux d’offrir à ses utilisateurs Radiant, une plateforme sécurisée permettant l’exploration et l’interprétation clinique des génomes individuels, afin d’accélérer le diagnostic moléculaire et de faire progresser la recherche en médecine de précision.',
           tag: 'Bientôt disponible',
         },
         stats: {

--- a/src/views/StudyEntity/SummaryHeader/index.module.css
+++ b/src/views/StudyEntity/SummaryHeader/index.module.css
@@ -48,3 +48,6 @@
 .buttonGroup .disableHover:hover {
   background-color: inherit;
 }
+.buttonGroup .buttonDisabled:hover {
+  background-color: var(--gray-3);
+}

--- a/src/views/StudyEntity/SummaryHeader/index.tsx
+++ b/src/views/StudyEntity/SummaryHeader/index.tsx
@@ -9,7 +9,7 @@ import {
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { numberFormat } from '@ferlab/ui/core/utils/numberUtils';
-import { Button, Popover } from 'antd';
+import { Button, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IStudyEntity } from 'graphql/studies/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -32,11 +32,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
       data-cy="SummaryHeader_Participants_Button"
       block
     >
-      <Popover
-        title={intl.get('entities.study.restrictedTitle')}
-        content={intl.get('entities.study.restrictedContent')}
-        trigger={isRestricted ? 'hover' : 'none'}
-      >
+      <Tooltip title={isRestricted ? intl.get('entities.study.restrictedTooltip') : ''}>
         <Link
           className={styles.link}
           to={setLoginModalUri ? '' : STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
@@ -70,7 +66,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
             <span className={styles.name}>{intl.get('entities.participant.participants')}</span>
           </div>
         </Link>
-      </Popover>
+      </Tooltip>
     </Button>
     <Button
       className={`${styles.button} ${styles.disableHover} ${isRestricted && styles.buttonDisabled}`}
@@ -78,11 +74,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
       data-cy="SummaryHeader_Families_Button"
       block
     >
-      <Popover
-        title={intl.get('entities.study.restrictedTitle')}
-        content={intl.get('entities.study.restrictedContent')}
-        trigger={isRestricted ? 'hover' : 'none'}
-      >
+      <Tooltip title={isRestricted ? intl.get('entities.study.restrictedTooltip') : ''}>
         <div className={styles.link}>
           <TeamOutlined className={styles.icon} />
           <div className={styles.alignBaseline}>
@@ -92,7 +84,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
             <span className={styles.name}>{intl.get('entities.participant.families')}</span>
           </div>
         </div>
-      </Popover>
+      </Tooltip>
     </Button>
     <Button
       className={`${styles.button} ${isRestricted && styles.buttonDisabled}`}
@@ -100,11 +92,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
       data-cy="SummaryHeader_Biospecimens_Button"
       block
     >
-      <Popover
-        title={intl.get('entities.study.restrictedTitle')}
-        content={intl.get('entities.study.restrictedContent')}
-        trigger={isRestricted ? 'hover' : 'none'}
-      >
+      <Tooltip title={isRestricted ? intl.get('entities.study.restrictedTooltip') : ''}>
         <Link
           className={styles.link}
           to={setLoginModalUri ? '' : STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
@@ -142,7 +130,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
             </span>
           </div>
         </Link>
-      </Popover>
+      </Tooltip>
     </Button>
     <Button
       className={`${styles.button} ${isRestricted && styles.buttonDisabled}`}
@@ -150,11 +138,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
       data-cy="SummaryHeader_Files_Button"
       block
     >
-      <Popover
-        title={intl.get('entities.study.restrictedTitle')}
-        content={intl.get('entities.study.restrictedContent')}
-        trigger={isRestricted ? 'hover' : 'none'}
-      >
+      <Tooltip title={isRestricted ? intl.get('entities.study.restrictedTooltip') : ''}>
         <Link
           className={styles.link}
           to={setLoginModalUri ? '' : STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
@@ -188,7 +172,7 @@ const SummaryHeader = ({ study, isRestricted, setLoginModalUri }: ISummaryBarPro
             <span className={styles.name}>{intl.get('entities.file.files')}</span>
           </div>
         </Link>
-      </Popover>
+      </Tooltip>
     </Button>
   </div>
 );


### PR DESCRIPTION
# feat(text): update radiant text and study summary tooltip

[CQDG-1246](https://ferlab-crsj.atlassian.net/browse/CQDG-1246)

## Description
Adjust radiant tile text
Study Entity Statistics block

## Acceptance Criterias
- Update text of radiant tile in landing page
- Use tooltip instead of popover for restricted study on statistic button

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->

### After

#### Landing page

<img width="805" height="462" alt="Capture d’écran, le 2025-10-17 à 11 09 25" src="https://github.com/user-attachments/assets/2774b3a6-016c-435e-acb0-b07f01d9315d" />
<img width="805" height="462" alt="Capture d’écran, le 2025-10-17 à 11 09 20" src="https://github.com/user-attachments/assets/61060e5d-3cf7-401c-9413-6220520c6c39" />

#### Study entity

https://github.com/user-attachments/assets/23f3da8d-ec3d-4f0f-b9ad-b3aecfbc79c3

https://github.com/user-attachments/assets/9ee52659-1ea4-4d6b-8295-a33dec32cacd



[CQDG-1246]: https://ferlab-crsj.atlassian.net/browse/CQDG-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ