### PR TITLE
feat: CQDG-1365 Added analysis type in data file facets

### DIFF
--- a/src/graphql/quickFilter/queries.ts
+++ b/src/graphql/quickFilter/queries.ts
@@ -136,6 +136,12 @@ export const GET_QUICK_FILTER_EXPLO = (lang: LANG) => {
               doc_count
             }
           }
+          files__sequencing_experiment__bio_informatic_analysis {
+            buckets {
+              key
+              doc_count
+            }
+          }
           files__data_type {
             buckets {
               key

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -441,6 +441,9 @@ export const getFacetsDictionary = () => ({
       display: intl.get('entities.file.strategy'),
     },
     platform: intl.get('entities.file.sequencing_experiment.platform'),
+    bio_informatic_analysis: intl.get(
+      'entities.file.sequencing_experiment.bio_informatic_analysis',
+    ),
     selection: {
       display: intl.get('entities.file.sequencing_experiment.selection'),
     },

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -179,6 +179,7 @@ const getDefaultColumns = (): ProColumnType[] => [
         0
       );
     },
+    defaultHidden: true,
   },
   {
     key: 'nb_biospecimens',
@@ -210,6 +211,7 @@ const getDefaultColumns = (): ProColumnType[] => [
         0
       );
     },
+    defaultHidden: true,
   },
   {
     key: 'file_name',

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -117,6 +117,14 @@ const getDefaultColumns = (): ProColumnType[] => [
     sorter: { multiple: 1 },
   },
   {
+    key: 'sequencing_experiment.bio_informatic_analysis',
+    title: intl.get('entities.file.sequencing_experiment.bio_informatic_analysis'),
+    dataIndex: 'sequencing_experiment',
+    sorter: { multiple: 1 },
+    render: (sequencing_experiment) =>
+      sequencing_experiment?.bio_informatic_analysis || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     key: 'data_type',
     title: intl.get('entities.file.data_type'),
     tooltip: <ExternalDataTypeLink />,

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -171,6 +171,7 @@ const getFilterGroups = (type: FilterTypes) => {
             facets: [
               'dataset',
               'data_category',
+              'sequencing_experiment__bio_informatic_analysis',
               'data_type',
               'sequencing_experiment__experimental_strategy',
               'sequencing_experiment__platform',


### PR DESCRIPTION
Added "Analysis Type" facet in the Data Explorer -> Data File view.

[Screencast from 2026-03-16 11-45-28.webm](https://github.com/user-attachments/assets/11a872d1-a71c-472a-ab0f-aac4ae8aacf2)

Added "Analysis Type" column to the Data Explorer -> Data File table and disabled by default "Participants" and "Biospecimens" column

<img width="1366" height="819" alt="Screenshot from 2026-03-16 12-15-18" src="https://github.com/user-attachments/assets/73496c85-a898-4c86-82ef-14bb6e32ba8b" />


## TODO
- [X] Disable Participants and Biospecimens by default in Data Files columns
- [X] Add analysis-type to table (enabled by default)