### PR TITLE
fix: CQDG-1361 Added null check for pipelines

### DIFF
--- a/src/views/FileEntity/utils/getAnalysisDescriptions.tsx
+++ b/src/views/FileEntity/utils/getAnalysisDescriptions.tsx
@@ -15,7 +15,7 @@ const getAnalysisDescriptions = (file?: IFileEntity): IEntityDescriptionsItem[] 
   },
   {
     label: intl.get('entities.file.sequencing_experiment.pipelines'),
-    value: file?.sequencing_experiment?.pipelines.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+    value: file?.sequencing_experiment?.pipelines?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.file.sequencing_experiment.genome_build'),


### PR DESCRIPTION
# fix: Added null check for pipelines

- Closes CQDG-1361

## Description
The file entity pages for studies other than the study1 were returning this error :
```
TypeError: can't access property "join", n.pipelines is null
```
since the ETL wasn't run for them. This hotfix adds a null check for the pipelines field while waiting for the studies to be ready to be run through the ETL.

## Acceptance Criterias
<!-- List all acceptance criteria from the ticket -->
Not show a 500 error.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1361)
- [Design](https://)
- [Ferlease](https://)

## Extra Validation
- [ ] Dev QA on ferlease
- [ ] Reviewer QA on ferlease 
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->
<img width="1914" height="928" alt="Screenshot from 2026-03-17 12-09-43" src="https://github.com/user-attachments/assets/001bd848-48c9-46cb-a6f7-6a1ae03d4aab" />

### After
<!-- Add screenshots/videos of the feature/bug after this PR -->
<img width="1914" height="928" alt="Screenshot from 2026-03-17 12-09-14" src="https://github.com/user-attachments/assets/37ba024b-a1db-4ea1-8d30-9438be507cad" />

## QA
### Steps to validate
<!-- Add step by step instructions to test this PR -->
1. Go in the data explorer
2. Go to the file entity page of any study files other than the ones for `study1`