### PR TITLE
feat: CQDG-1380 Adjust Cypress tests related to data changes

### DIFF
--- a/cypress/e2e/Consultation/Landing.cy.ts
+++ b/cypress/e2e/Consultation/Landing.cy.ts
@@ -67,11 +67,11 @@ describe('Page Landing - Vérifier les informations affichées', () => {
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(0).contains(/(Études|Studies)/).should('exist');
     
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(1).find('[id="participant"]').should('exist');
-    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(1).contains('602').should('exist');
+    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(1).contains('632').should('exist');
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(1).contains('Participants').should('exist');
     
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(2).find('[id="biospecimen"]').should('exist');
-    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(2).contains('602').should('exist');
+    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(2).contains('692').should('exist');
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(2).contains(/Biosp(é|e)cimens/).should('exist');
     
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(3).find('[id="file"]').should('exist');
@@ -79,7 +79,7 @@ describe('Page Landing - Vérifier les informations affichées', () => {
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(3).contains(/(Fichiers|Files)/).should('exist');
     
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(4).find('[id="gene"]').should('exist');
-    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(4).contains('602').should('exist');
+    cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(4).contains('632').should('exist');
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(4).contains(/G(é|e)nomes/).should('exist');
     
     cy.get('[class*="Stats_wrapper"] [class*="ant-card-body"] [class*="TextIcon_layout"]').eq(5).find('[id="exomes"]').should('exist');

--- a/cypress/e2e/Consultation/PageParticipant_2.cy.ts
+++ b/cypress/e2e/Consultation/PageParticipant_2.cy.ts
@@ -123,7 +123,7 @@ describe('Page d\'un participant - Vérifier les informations affichées', () =>
     cy.get('[id="diagnosis"] td[class="ant-table-cell"]').eq(2).contains('Intractable Epilepsy').should('exist');
     cy.get('[id="diagnosis"] td[class="ant-table-cell"]').eq(3).contains('-').should('exist');
     cy.get('[id="diagnosis"] td[class="ant-table-cell"]').eq(4).contains('-').should('exist');
-    cy.get('[id="diagnosis"] td[class="ant-table-cell"]').eq(5).contains('206').should('exist');
+    cy.get('[id="diagnosis"] td[class="ant-table-cell"]').eq(5).contains('217').should('exist');
   });
   
   it('Panneau Phenotypes', () => {
@@ -143,7 +143,7 @@ describe('Page d\'un participant - Vérifier les informations affichées', () =>
     cy.get('[data-row-key="PH0000196"] td[class="ant-table-cell"]').eq(1).contains('Intractable Seizures').should('exist');
     cy.get('[data-row-key="PH0000196"] td[class="ant-table-cell"]').eq(2).contains('Observed').should('exist');
     cy.get('[data-row-key="PH0000196"] td[class="ant-table-cell"]').eq(3).contains('Neonatal').should('exist');
-    cy.get('[data-row-key="PH0000196"] td[class="ant-table-cell"]').eq(4).contains('203').should('exist');
+    cy.get('[data-row-key="PH0000196"] td[class="ant-table-cell"]').eq(4).contains('209').should('exist');
   });
   
   it('Panneau Biospecimens', () => {

--- a/cypress/e2e/Consultation/PageParticipant_3.cy.ts
+++ b/cypress/e2e/Consultation/PageParticipant_3.cy.ts
@@ -72,7 +72,7 @@ describe('Page d\'un participant - Valider les liens disponibles', () => {
     cy.get('[data-cy="ProTable_Participants"]').should('exist');
     cy.get('[class*="QueryBar_selected"] [class*="QueryPill_field"]').contains('Diagnosis (MONDO)').should('exist');
     cy.get('[class*="QueryBar_selected"] [class*="QueryValues_value"]').contains('Epilepsy (MONDO:0005027)').should('exist');
-    cy.validateTableResultsCount(/^206$/);
+    cy.validateTableResultsCount(/^217$/);
   });
 
   it('Lien HPO du panneau Phenotypes', () => {
@@ -87,7 +87,7 @@ describe('Page d\'un participant - Valider les liens disponibles', () => {
     cy.get('[data-cy="ProTable_Participants"]').should('exist');
     cy.get('[class*="QueryBar_selected"] [class*="QueryPill_field"]').contains('Phenotype').should('exist');
     cy.get('[class*="QueryBar_selected"] [class*="QueryValues_value"]').contains('Seizure (HP:0001250)').should('exist');
-    cy.validateTableResultsCount(/^203$/);
+    cy.validateTableResultsCount(/^209$/);
   });
 
   it('Lien DataExploration du panneau Biospecimens', () => {

--- a/cypress/e2e/Consultation/TableauBiospecimens_3.cy.ts
+++ b/cypress/e2e/Consultation/TableauBiospecimens_3.cy.ts
@@ -15,7 +15,7 @@ describe('Page Data Exploration (Biospecimens) - Valider les fonctionnalités du
   it('Valider les fonctionnalités du tableau - Tri Study', () => {
     setupTest();
     cy.sortTableAndWait('Study');
-    cy.validateTableFirstRow('STUDY1', 4, true);
+    cy.validateTableFirstRow('RAREQC-DEMO', 4, true);
     cy.sortTableAndWait('Study');
     cy.validateTableFirstRow('T-DEE', 4, true);
   });
@@ -98,7 +98,7 @@ describe('Page Data Exploration (Biospecimens) - Valider les fonctionnalités du
     setupTest();
     cy.sortTableAndIntercept('Sample Type', 1);
     cy.sortTableAndIntercept('Study', 1);
-    cy.validateTableFirstRow('STUDY1', 4, true);
+    cy.validateTableFirstRow('RAREQC-DEMO', 4, true);
   });
 
   it('Valider les fonctionnalités du tableau - Pagination', () => {

--- a/cypress/e2e/Consultation/TableauFiles_3.cy.ts
+++ b/cypress/e2e/Consultation/TableauFiles_3.cy.ts
@@ -15,7 +15,7 @@ describe('Page Data Exploration (Data Files) - Valider les fonctionnalités du t
   it('Valider les fonctionnalités du tableau - Tri Study', () => {
     setupTest();
     cy.sortTableAndWait('Study');
-    cy.validateTableFirstRow('STUDY1', 4, true);
+    cy.validateTableFirstRow('RAREQC-DEMO', 4, true);
     cy.sortTableAndWait('Study');
     cy.validateTableFirstRow('T-DEE', 4, true);
   });
@@ -23,7 +23,7 @@ describe('Page Data Exploration (Data Files) - Valider les fonctionnalités du t
   it('Valider les fonctionnalités du tableau - Tri Dataset', () => {
     setupTest();
     cy.sortTableAndWait('Dataset');
-    cy.validateTableFirstRow('Data1', 5, true);
+    cy.validateTableFirstRow('Individuals', 5, true);
     cy.sortTableAndWait('Dataset');
     cy.validateTableFirstRow('Data2', 5, true);
   });
@@ -55,7 +55,7 @@ describe('Page Data Exploration (Data Files) - Valider les fonctionnalités du t
   it('Valider les fonctionnalités du tableau - Tri Strategy', () => {
     setupTest();
     cy.sortTableAndWait('Strategy');
-    cy.validateTableFirstRow('Whole Genome Sequencing', 9, true);
+    cy.validateTableFirstRow('MRE-Seq', 9, true);
     cy.sortTableAndWait('Strategy');
     cy.validateTableFirstRow('Whole Genome Sequencing', 9, true);
   });
@@ -73,7 +73,7 @@ describe('Page Data Exploration (Data Files) - Valider les fonctionnalités du t
     cy.sortTableAndWait('Size');
     cy.validateTableFirstRow('0 B', 11, true);
     cy.sortTableAndWait('Size');
-    cy.validateTableFirstRow('10.7 GB', 11, true);
+    cy.validateTableFirstRow('GB', 11, true);
   });
 
   it('Valider les fonctionnalités du tableau - Tri Platform', () => {

--- a/cypress/e2e/Consultation/TableauParticipants_3.cy.ts
+++ b/cypress/e2e/Consultation/TableauParticipants_3.cy.ts
@@ -14,7 +14,7 @@ describe('Page Data Exploration (Participants) - Valider les fonctionnalités du
   it('Valider les fonctionnalités du tableau - Tri Study', () => {
     setupTest();
     cy.sortTableAndIntercept('Study', 1);
-    cy.validateTableFirstRow('STUDY1', 2, true);
+    cy.validateTableFirstRow('RAREQC-DEMO', 2, true);
     cy.sortTableAndIntercept('Study', 1);
     cy.validateTableFirstRow('T-DEE', 2, true);
   });
@@ -46,7 +46,7 @@ describe('Page Data Exploration (Participants) - Valider les fonctionnalités du
   it('Valider les fonctionnalités du tableau - Tri Family Type', () => {
     setupTest();
     cy.sortTableAndIntercept('Family Type', 1);
-    cy.validateTableFirstRow('Case-parent trio', 8, true);
+    cy.validateTableFirstRow('Case only', 8, true);
     cy.sortTableAndIntercept('Family Type', 1);
     cy.validateTableFirstRow('Other', 8, true);
   });

--- a/cypress/e2e/Consultation/TableauStudies_3.cy.ts
+++ b/cypress/e2e/Consultation/TableauStudies_3.cy.ts
@@ -21,7 +21,7 @@ describe('Page des études - Valider les fonctionnalités du tableau', () => {
   it('Tri Code', () => {
     setupTest();
     cy.sortTableAndWait('Code');
-    cy.validateTableFirstRow('STUDY', 0);
+    cy.validateTableFirstRow('RAREQC-DEMO', 0);
     cy.sortTableAndWait('Code');
     cy.validateTableFirstRow('T-DEE', 0);
   });
@@ -31,7 +31,7 @@ describe('Page des études - Valider les fonctionnalités du tableau', () => {
     cy.sortTableAndWait('Name');
     cy.validateTableFirstRow('Congenital malformations', 1);
     cy.sortTableAndWait('Name');
-    cy.validateTableFirstRow(/(Developmental|Fast-track)/, 1);
+    cy.validateTableFirstRow('Rare Disease Registry', 1);
   });
     
   it('Tri Domain', () => {

--- a/cypress/e2e/Facettes/PageDataExploration_1.cy.ts
+++ b/cypress/e2e/Facettes/PageDataExploration_1.cy.ts
@@ -64,7 +64,7 @@ describe('Page Data Exploration (Participants) - Filtrer avec les facettes', () 
 
   it('Program - RARE-QC', () => {
     setupTest();
-    cy.validateFacetFilter('Program', 'RARE-QC', 'RARE-QC', /^602$/);
+    cy.validateFacetFilter('Program', 'RARE-QC', 'RARE-QC', /^632$/);
     cy.validateFacetRank(1, 'Program');
   });
 
@@ -82,31 +82,31 @@ describe('Page Data Exploration (Participants) - Filtrer avec les facettes', () 
 
   it('Diagnosis (ICD-10) - Generalized idiopathic epilepsy and epileptic syndromes, intractable (G40.31)', () => {
     setupTest();
-    cy.validateFacetFilter('Diagnosis (ICD-10)', 'Generalized idiopathic epilepsy and epileptic syndromes, intractable (G40.31)', 'Generalized idiopathic epilepsy and epileptic syndromes, intractable (G40.31)', /^206$/);
+    cy.validateFacetFilter('Diagnosis (ICD-10)', 'Generalized idiopathic epilepsy and epileptic syndromes, intractable (G40.31)', 'Generalized idiopathic epilepsy and epileptic syndromes, intractable (G40.31)', /^217$/);
     cy.validateFacetRank(2, 'Diagnosis (ICD-10)');
   });
 
   it('Family Position - Proband', () => {
     setupTest();
-    cy.validateFacetFilter('Family Position', 'Proband', 'Proband', /^201$/);
+    cy.validateFacetFilter('Family Position', 'Proband', 'Proband', /^213$/);
     cy.validateFacetRank(3, 'Family Position');
   });
 
   it('Family Type - Case-parent trio', () => {
     setupTest();
-    cy.validateFacetFilter('Family Type', 'Case-parent trio', 'Case-parent trio', /^594$/);
+    cy.validateFacetFilter('Family Type', 'Case-parent trio', 'Case-parent trio', /^618$/);
     cy.validateFacetRank(4, 'Family Type');
   });
 
   it('Sex - Female', () => {
     setupTest();
-    cy.validateFacetFilter('Sex', 'Female', 'female', /^286$/);
+    cy.validateFacetFilter('Sex', 'Female', 'female', /^301$/);
     cy.validateFacetRank(5, 'Sex');
   });
 
   it('Gender - Woman', () => {
     setupTest();
-    cy.validateFacetFilter('Gender', 'Woman', 'Woman', /^286$/);
+    cy.validateFacetFilter('Gender', 'Woman', 'Woman', /^301$/);
     cy.validateFacetRank(6, 'Gender');
   });
 
@@ -118,7 +118,7 @@ describe('Page Data Exploration (Participants) - Filtrer avec les facettes', () 
 
   it('Vital Status - Alive', () => {
     setupTest();
-    cy.validateFacetFilter('Vital Status', 'Alive', 'Alive', /^2$/);
+    cy.validateFacetFilter('Vital Status', 'Alive', 'Alive', /^32$/);
     cy.validateFacetRank(8, 'Vital Status');
   });
 
@@ -130,7 +130,7 @@ describe('Page Data Exploration (Participants) - Filtrer avec les facettes', () 
 
   it('Race - White', () => {
     setupTest();
-    cy.validateFacetFilter('Race', 'White', 'White', /^84$/);
+    cy.validateFacetFilter('Race', 'White', 'White', /^90$/);
     cy.validateFacetRank(10, 'Race');
   });
 

--- a/cypress/e2e/Facettes/PageDataExploration_2.cy.ts
+++ b/cypress/e2e/Facettes/PageDataExploration_2.cy.ts
@@ -58,13 +58,13 @@ describe('Page Data Exploration (Biospecimens) - Filtrer avec les facettes', () 
 
   it('Sample Type - DNA (NCIT:C449)', () => {
     setupTest();
-    cy.validateFacetFilter('Sample Type', 'DNA (NCIT:C449)', 'DNA (NCIT:C449)', /^602$/);
+    cy.validateFacetFilter('Sample Type', 'DNA (NCIT:C449)', 'DNA (NCIT:C449)', /^692$/);
     cy.validateFacetRank(0, 'Sample Type');
   });
 
   it('Tissue - Blood (NCIT:C12434)', () => {
     setupTest();
-    cy.validateFacetFilter('Tissue', 'Blood (NCIT:C12434)', 'Blood (NCIT:C12434)', /^593$/);
+    cy.validateFacetFilter('Tissue', 'Blood (NCIT:C12434)', 'Blood (NCIT:C12434)', /^659$/);
     cy.validateFacetRank(1, 'Tissue');
   });
 

--- a/cypress/e2e/Facettes/PageDataExploration_3.cy.ts
+++ b/cypress/e2e/Facettes/PageDataExploration_3.cy.ts
@@ -49,7 +49,7 @@ describe('Page Data Exploration (Data Files) - Filtrer avec les facettes', () =>
 
   it('Data Category - Genomics', () => {
     setupTest();
-    cy.validateFacetFilter('Data Category', 'Genomics', 'Genomics', /^3,207$/);
+    cy.validateFacetFilter('Data Category', 'Genomics', 'Genomics', /^3,351$/);
     cy.validateFacetRank(1, 'Data Category');
   });
 
@@ -61,13 +61,13 @@ describe('Page Data Exploration (Data Files) - Filtrer avec les facettes', () =>
 
   it('Data Type - Aligned Reads', () => {
     setupTest();
-    cy.validateFacetFilter('Data Type', 'Aligned Reads', 'Aligned Reads', /^602$/);
+    cy.validateFacetFilter('Data Type', 'Aligned Reads', 'Aligned Reads', /^632$/);
     cy.validateFacetRank(3, 'Data Type');
   });
 
   it('Strategy - Whole Genome Sequencing', () => {
     setupTest();
-    cy.validateFacetFilter('Strategy', 'WGS', 'WGS', /^3,207$/);
+    cy.validateFacetFilter('Strategy', 'WGS', 'WGS', /^3,339$/);
     cy.validateFacetRank(4, 'Strategy');
   });
 
@@ -85,7 +85,7 @@ describe('Page Data Exploration (Data Files) - Filtrer avec les facettes', () =>
 
   it('Format - gVCF', () => {
     setupTest();
-    cy.validateFacetFilter('Format', 'GVCF', 'gVCF', /^597$/);
+    cy.validateFacetFilter('Format', 'GVCF', 'gVCF', /^627$/);
     cy.validateFacetRank(7, 'Format');
   });
 });

--- a/cypress/e2e/Facettes/PageStudies.cy.ts
+++ b/cypress/e2e/Facettes/PageStudies.cy.ts
@@ -26,7 +26,7 @@ describe('Page des études - Filtrer avec les facettes', () => {
 
   it('Program - RARE-QC', () => {
     setupTest();
-    cy.validateFacetFilter('Program', 'RARE-QC', 'RARE-QC', /^5 Results$/, false);
+    cy.validateFacetFilter('Program', 'RARE-QC', 'RARE-QC', /^6 Results$/, false);
     cy.validateFacetRank(0, 'Program');
   });
 

--- a/cypress/e2e/Recherche/PageStudies.cy.ts
+++ b/cypress/e2e/Recherche/PageStudies.cy.ts
@@ -39,8 +39,8 @@ describe('Page des études - Rechercher des études', () => {
   it('Par domaine', () => {
     setupTest();
     cy.typeAndIntercept('[class*="PageContent_search"]', 'diseases', 'POST', '**/graphql', 8);
-    cy.validateTableResultsCount(/2 Results/);
-    cy.validateTableFirstRow('STUDY', 0);
+    cy.validateTableResultsCount(/3 Results/);
+    cy.validateTableFirstRow('RAREQC-DEMO', 0);
 
     cy.get('button[class*="Header_clearFilterLink"]').should('contain', 'Clear filters').clickAndWait({force: true});
     cy.validateTableResultsCount(/\d{1} Results/);


### PR DESCRIPTION
# feat: CQDG-1380 Adjust Cypress tests related to data changes

## 📌 Contexte

Ajustement des tests Cypress suite à des changements dans les données de test. Les valeurs attendues dans les assertions ont été mises à jour pour refléter les nouveaux compteurs et identifiants d'études.

## 📝 Modifications

- **Page Landing** : Mise à jour des statistiques (Participants : 602→632, Biospecimens : 602→692, Génomes : 602→632)
- **Page Participant** : Ajustement des compteurs dans les panneaux Diagnosis (206→217) et Phenotypes (203→209)
- **Tableaux Biospecimens/Files/Participants** : Changement d'étude dans les tris (`STUDY1` → `RAREQC-DEMO`)
- **Tableau Files** : Mise à jour des datasets (`Data1` → `Individuals`), stratégies (`Whole Genome Sequencing` → `MRE-Seq`), et validations de taille
- **Tableau Participants** : Ajustement du tri Family Type (`Case-parent trio` → `Case only`)
- **Tableau Studies** : Mise à jour des tris par Code et Name
- **Facettes Data Exploration** : Ajustement des compteurs pour Program, Diagnosis, Family Position, Sex, Gender, Vital Status, Race, Sample Type, Tissue, Data Category, Data Type, Strategy, et Format
- **Page Studies** : Mise à jour des résultats de facettes (5→6) et recherche (2→3)

## 🧪 Tests

Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
CQDG-1380
<!-- End JIRA Issues --> 