### PR TITLE
fix: CQDG-1384 Replaced capture kit with target capture kit

### DIFF
--- a/src/graphql/files/models.ts
+++ b/src/graphql/files/models.ts
@@ -16,6 +16,7 @@ export interface IFileSequencingExperiment {
   alir: string;
   bio_informatic_analysis: string;
   capture_kit: string;
+  target_capture_kit: string;
   experimental_strategy: string;
   experimental_strategy_1: ICodeDisplay;
   gcnv: string;

--- a/src/graphql/files/queries.ts
+++ b/src/graphql/files/queries.ts
@@ -64,6 +64,7 @@ export const GET_FILES = gql`
               read_length
               platform
               capture_kit
+              target_capture_kit
               sequencer_id
               run_name
               labAliquotID

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -183,7 +183,7 @@ const en = {
         type_of_sequencing: 'Sequencing Type',
         read_length: 'Read Length',
         platform: 'Platform',
-        capture_kit: 'Capture Kit',
+        target_capture_kit: 'Capture Kit',
         sequencer_id: 'Sequencer',
         run_name: 'Run',
         labAliquotID: 'Aliquot',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -187,7 +187,7 @@ const fr = {
         type_of_sequencing: 'Type de séquençage',
         read_length: 'Longueur des fragments',
         platform: 'Plateforme',
-        capture_kit: 'Kit de capture',
+        target_capture_kit: 'Kit de capture',
         sequencer_id: 'Séquenceur',
         run_name: 'Run',
         labAliquotID: 'Aliquot',

--- a/src/views/FileEntity/utils/getExperimentalProcedureDescriptions.tsx
+++ b/src/views/FileEntity/utils/getExperimentalProcedureDescriptions.tsx
@@ -33,8 +33,8 @@ const getExperimentalProcedureDescriptions = (file?: IFileEntity): IEntityDescri
     value: file?.sequencing_experiment?.selection?.display || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    label: intl.get('entities.file.sequencing_experiment.capture_kit'),
-    value: file?.sequencing_experiment?.capture_kit || TABLE_EMPTY_PLACE_HOLDER,
+    label: intl.get('entities.file.sequencing_experiment.target_capture_kit'),
+    value: file?.sequencing_experiment?.target_capture_kit || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.file.sequencing_experiment.target_loci'),

--- a/src/views/FileEntity/utils/getExperimentalProcedureDescriptions.tsx
+++ b/src/views/FileEntity/utils/getExperimentalProcedureDescriptions.tsx
@@ -34,7 +34,10 @@ const getExperimentalProcedureDescriptions = (file?: IFileEntity): IEntityDescri
   },
   {
     label: intl.get('entities.file.sequencing_experiment.target_capture_kit'),
-    value: file?.sequencing_experiment?.target_capture_kit || TABLE_EMPTY_PLACE_HOLDER,
+    value:
+      file?.sequencing_experiment?.capture_kit ||
+      file?.sequencing_experiment?.target_capture_kit ||
+      TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.file.sequencing_experiment.target_loci'),


### PR DESCRIPTION
# fix: Replaced capture kit with target capture kit

- Closes CQDG-1384

## Description

Uses the `target_capture_kit` value instead of the deprecated `capture_kit` value, making the "Capture Kit" value visible in the portal.

<img width="1599" height="496" alt="image" src="https://github.com/user-attachments/assets/6f9ae99f-ec2c-46e5-a386-bba8a0da64c6" />

I also kept `capture_kit` if present in the query response for backward compatibility.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1384)
- [Design](https://)
- [Ferlease](https://)

## Extra Validation
- [ ] Dev QA on ferlease
- [ ] Reviewer QA on ferlease 
- [ ] QA Done
- [ ] Design/UI Approved from design