### PR TITLE
feat: CQDG-1412 Added warning text when duplicate files included in manifest

### DIFF
--- a/src/components/reports/DownloadFileManifestModal/FilesTable.tsx
+++ b/src/components/reports/DownloadFileManifestModal/FilesTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import intl from 'react-intl-universal';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
@@ -20,39 +20,60 @@ interface IFileByDataType {
   value: string;
   nb_participants: number;
   nb_files: number;
+  nb_files_skipped?: number;
   size: number;
 }
 
-export const getDataTypeColumns = (): ProColumnType<any>[] => [
-  {
-    key: 'value',
-    dataIndex: 'value',
-    title: intl.get('entities.file.data_type'),
-    render: (label: string) => label || TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
-    key: 'nb_participants',
-    dataIndex: 'nb_participants',
-    title: intl.get('entities.participant.participants'),
-    render: (nb_participants: number) =>
-      nb_participants ? numberFormat(nb_participants) : TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
-    key: 'nb_files',
-    dataIndex: 'nb_files',
-    title: intl.get('entities.file.files'),
-    render: (nb_files: number) => (nb_files ? numberFormat(nb_files) : TABLE_EMPTY_PLACE_HOLDER),
-  },
-  {
+export const getDataTypeColumns = (showSkipped: boolean): ProColumnType<any>[] => {
+  const columns: ProColumnType<any>[] = [
+    {
+      key: 'value',
+      dataIndex: 'value',
+      title: intl.get('entities.file.data_type'),
+      render: (label: string) => label || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      key: 'nb_participants',
+      dataIndex: 'nb_participants',
+      title: intl.get('entities.participant.participants'),
+      render: (nb_participants: number) =>
+        nb_participants ? numberFormat(nb_participants) : TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      key: 'nb_files',
+      dataIndex: 'nb_files',
+      title: intl.get('entities.file.files'),
+      render: (nb_files: number) => (nb_files ? numberFormat(nb_files) : TABLE_EMPTY_PLACE_HOLDER),
+    },
+  ];
+
+  if (showSkipped) {
+    columns.push({
+      key: 'nb_files_skipped',
+      dataIndex: 'nb_files_skipped',
+      title: `${intl.get('entities.file.files_skipped')} *`,
+      render: (nb_files_skipped: number) =>
+        nb_files_skipped ? numberFormat(nb_files_skipped) : TABLE_EMPTY_PLACE_HOLDER,
+    });
+  }
+
+  columns.push({
     key: 'size',
     dataIndex: 'size',
     title: intl.get('entities.file.file_size'),
     render: (size: number) =>
       formatFileSize(size, { output: 'string' }) || TABLE_EMPTY_PLACE_HOLDER,
-  },
-];
+  });
 
-const FilesTable = ({ sqon }: { sqon: ISyntheticSqon }) => {
+  return columns;
+};
+
+interface IFilesTableProps {
+  sqon: ISyntheticSqon;
+  onSkippedFilesChange?: (hasSkipped: boolean) => void;
+}
+
+const FilesTable = ({ sqon, onSkippedFilesChange }: IFilesTableProps) => {
   const config: AxiosRequestConfig = {
     url: REPORTS_ROUTES[ReportType.FILE_MANIFEST_STATS],
     method: 'POST',
@@ -67,9 +88,15 @@ const FilesTable = ({ sqon }: { sqon: ISyntheticSqon }) => {
   const cachedConfig = useMemo(() => config, []);
   const { loading, result: files = [] } = useApi<IFileByDataType[]>({ config: cachedConfig });
 
+  const hasSkippedFiles = files.some((file) => (file.nb_files_skipped ?? 0) > 0);
+
+  useEffect(() => {
+    onSkippedFilesChange?.(hasSkippedFiles);
+  }, [hasSkippedFiles, onSkippedFilesChange]);
+
   return (
     <Table
-      columns={getDataTypeColumns()}
+      columns={getDataTypeColumns(hasSkippedFiles)}
       dataSource={files}
       pagination={false}
       size="small"

--- a/src/components/reports/DownloadFileManifestModal/index.module.css
+++ b/src/components/reports/DownloadFileManifestModal/index.module.css
@@ -24,6 +24,13 @@
   font-weight: 600;
 }
 
+.duplicatesMessage {
+  margin-top: 8px;
+  margin-bottom: 0;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 .externalLinkFerload {
   color: inherit;
 }

--- a/src/components/reports/DownloadFileManifestModal/index.tsx
+++ b/src/components/reports/DownloadFileManifestModal/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
@@ -55,11 +55,18 @@ const DownloadFileManifestModal = ({
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isFamilyChecked, setIsFamilyChecked] = useState(false);
+  const [hasSkippedFiles, setHasSkippedFiles] = useState(false);
   const { isLoading } = useSavedSet();
 
   const handleClose = () => {
     setIsModalVisible(false);
+    setHasSkippedFiles(false);
   };
+
+  const handleSkippedFilesChange = useCallback(
+    (hasSkipped: boolean) => setHasSkippedFiles(hasSkipped),
+    [],
+  );
 
   const Content = () => (
     <Text>
@@ -217,8 +224,15 @@ const DownloadFileManifestModal = ({
             </Checkbox>
           )
         }
+        {hasSkippedFiles && (
+          <p className={styles.duplicatesMessage}>
+            * {intl.get('api.report.fileManifest.duplicatesSkipped')}
+          </p>
+        )}
         {hasTooManyFiles && <TooMuchFilesAlert />}
-        {!hasTooManyFiles && isModalVisible && <FilesTable sqon={sqon} />}
+        {!hasTooManyFiles && isModalVisible && (
+          <FilesTable sqon={sqon} onSkippedFilesChange={handleSkippedFilesChange} />
+        )}
       </Modal>
     </Tooltip>
   );

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -701,7 +701,7 @@ const en = {
         manifestIdCopySuccess: 'ID copied to clipboard',
         manifestIdCopyError: 'ID copy to clipboard error',
         duplicatesSkipped:
-          'Some of the selected files contain duplicates and will not be downloaded. The Size does not include the skipped files.',
+          'Your selection includes one or more files attributed to multiple samples (for example, a study-wide file or a supplement associated with a sequencing experiment). Only one copy will be included in the manifest.',
       },
       requestAccess: {
         button: 'Request access',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -154,6 +154,7 @@ const en = {
       file_name: 'File Name',
       file_format: 'Format',
       file_size: 'Size',
+      files_skipped: 'Files skipped',
       ferload_url: 'URL',
       file_hash: 'Hash',
       analysis: 'Analysis',
@@ -699,6 +700,8 @@ const en = {
         manifestIdButtonTooltip: 'Copy the manifest ID for use in ',
         manifestIdCopySuccess: 'ID copied to clipboard',
         manifestIdCopyError: 'ID copy to clipboard error',
+        duplicatesSkipped:
+          'Some of the selected files contain duplicates and will not be downloaded.',
       },
       requestAccess: {
         button: 'Request access',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -701,7 +701,7 @@ const en = {
         manifestIdCopySuccess: 'ID copied to clipboard',
         manifestIdCopyError: 'ID copy to clipboard error',
         duplicatesSkipped:
-          'Some of the selected files contain duplicates and will not be downloaded.',
+          'Some of the selected files contain duplicates and will not be downloaded. The Size does not include the skipped files.',
       },
       requestAccess: {
         button: 'Request access',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -705,7 +705,7 @@ const fr = {
         manifestIdCopySuccess: 'Identifiant copié dans le presse-papiers',
         manifestIdCopyError: 'Erreur de copie de l’identifiant dans le presse-papiers',
         duplicatesSkipped:
-          'Certains des fichiers sélectionnés contiennent des doublons et ne seront pas téléchargés. La Taille ne tient pas compte des fichiers ignorés.',
+          'Votre sélection contient un ou plusieurs fichiers associés à plusieurs échantillons (par exemple un fichier associé à l’étude complète ou un supplément associé à une expérience de séquençage). Une seule copie sera incluse dans le manifeste.',
       },
       requestAccess: {
         button: 'Demande d’accès',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -155,6 +155,7 @@ const fr = {
       file_name: 'Nom du fichier',
       file_format: 'Format',
       file_size: 'Taille',
+      files_skipped: 'Fichiers ignorés',
       ferload_url: 'URL',
       file_hash: 'Hash',
       participants: '{count, plural, =0 {Participant} =1 {Participant} other {Participants}}',
@@ -703,6 +704,8 @@ const fr = {
         manifestIdButtonTooltip: "Copiez l'identifiant du manifeste à utiliser avec ",
         manifestIdCopySuccess: 'Identifiant copié dans le presse-papiers',
         manifestIdCopyError: 'Erreur de copie de l’identifiant dans le presse-papiers',
+        duplicatesSkipped:
+          'Certains des fichiers sélectionnés contiennent des doublons et ne seront pas téléchargés.',
       },
       requestAccess: {
         button: 'Demande d’accès',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -705,7 +705,7 @@ const fr = {
         manifestIdCopySuccess: 'Identifiant copié dans le presse-papiers',
         manifestIdCopyError: 'Erreur de copie de l’identifiant dans le presse-papiers',
         duplicatesSkipped:
-          'Certains des fichiers sélectionnés contiennent des doublons et ne seront pas téléchargés.',
+          'Certains des fichiers sélectionnés contiennent des doublons et ne seront pas téléchargés. La Taille ne tient pas compte des fichiers ignorés.',
       },
       requestAccess: {
         button: 'Demande d’accès',


### PR DESCRIPTION
# feat: Updated duplicate file dialog text

- Closes CQDG-1412

## Description

This PR adds details when the user is about to download a manifest (ferload) containing duplicate files since they share the same path. Also added french translation.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1412)
- [Ferlease](https://portal-ui-cqdg-1412.qa.juno.cqdg.ferlab.bio/)

## Extra Validation
- [ ] Dev QA on ferlease
- [ ] Reviewer QA on ferlease 
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
<img width="1917" height="772" alt="image" src="https://github.com/user-attachments/assets/dd3c3a16-9c7c-4cf4-a865-16ac9a3a8a79" />


### After
<img width="1917" height="772" alt="Screenshot from 2026-05-04 11-18-07" src="https://github.com/user-attachments/assets/ca00dc8e-06b4-44f5-9673-17da9b068885" />


## QA
### Steps to validate
<!-- Add step by step instructions to test this PR -->
1. Find files with the same path (internally) - Use `FI0012008` and `FI0012011` from the study `study-msfiles`
2. Clic on the download manifest button